### PR TITLE
[ccm] Use clusterName in generated cloud-config

### DIFF
--- a/charts/cluster-addons/templates/openstack/cloud-config.yaml
+++ b/charts/cluster-addons/templates/openstack/cloud-config.yaml
@@ -23,7 +23,7 @@ spec:
             [Global]
             use-clouds=true
             clouds-file=/etc/config/clouds.yaml
-            cloud=openstack
+            cloud={{ .Values.clusterName | default "openstack" }}
         {%- if "cacert" in cloud_identity.data %}
             ca-file=/etc/config/cacert
         {%- else %}


### PR DESCRIPTION
If the entry in the cloud-config file doesn't match the name of the cluster, then CCM fails to start and throws an error.  To fix this, we use clusterName if specified, otherwise fall back to the previous default of `openstack`.