### PR TITLE
Allow configuration of Calico bgp and encapsulation values

### DIFF
--- a/charts/cluster-addons/templates/cni/calico.yaml
+++ b/charts/cluster-addons/templates/cni/calico.yaml
@@ -13,7 +13,7 @@ stringData:
       nodeMetricsPort: 9091
       typhaMetricsPort: 9093
       calicoNetwork:
-        bgp: Disabled
+        bgp: {{ .Values.cni.calico.bgp }}
         nodeAddressAutodetectionV4:
           kubernetes: NodeInternalIP
         ipPools:
@@ -21,7 +21,7 @@ stringData:
           - blockSize: 26
             cidr: {{ "{{" }} cidr {{ "}}" }}
             disableBGPExport: false
-            encapsulation: VXLAN
+            encapsulation: {{ .Values.cni.calico.encapsulation }}
             natOutgoing: Enabled
             nodeSelector: all()
     {% endfor %}

--- a/charts/cluster-addons/values.yaml
+++ b/charts/cluster-addons/values.yaml
@@ -12,7 +12,13 @@ cni:
   type: calico
   # Settings for the calico CNI
   # See https://projectcalico.docs.tigera.io/getting-started/kubernetes/helm
+  # Defaults in this Helm chart for encapsulation and bgp are for VXLAN.
+  # To enable BGP mode Calico:
+  # 1. Set encapsulation:None and bgp:Enabled
+  # 2. Ensure all nodes have the pod CIDR in allowed address pairs on network ports.
   calico:
+    bgp: Disabled
+    encapsulation: VXLAN
     chart:
       repo: https://projectcalico.docs.tigera.io/charts
       name: tigera-operator


### PR DESCRIPTION
To enable Calico BGP mode we need to set bgp and encapsulation values. The chart allows overriding of the bgp value already, but encapsulation is within a list, which is concatenated if changes are attempted in the overrides field.

So, here we add configuration for both values and document how to enable the full-mesh mode we will use.