### PR TITLE
Truncate secret names to prevent going over 63 char limit.

### DIFF
--- a/charts/cluster-addons/templates/_helpers.tpl
+++ b/charts/cluster-addons/templates/_helpers.tpl
@@ -7,11 +7,12 @@ The name of the target cluster.
 
 {{/*
 Create a name for a cluster component.
+Truncate to 59 to allow "-cfg" to be appended as needed.
 */}}
 {{- define "cluster-addons.componentName" -}}
 {{- $ctx := index . 0 -}}
 {{- $componentName := index . 1 -}}
-{{- printf "%s-%s" $ctx.Release.Name $componentName | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" $ctx.Release.Name $componentName | trunc 59 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/charts/cluster-addons/templates/cni/calico.yaml
+++ b/charts/cluster-addons/templates/cni/calico.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "cni-calico") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "cni-calico") }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list . "cni-calico") | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -44,10 +44,10 @@ spec:
   releaseName: cni-calico
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "cni-calico") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "cni-calico") }}-cfg
         key: defaults
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "cni-calico") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "cni-calico") }}-cfg
         key: overrides
 {{- if .Values.cni.calico.globalNetworkPolicy }}
 ---

--- a/charts/cluster-addons/templates/cni/cilium.yaml
+++ b/charts/cluster-addons/templates/cni/cilium.yaml
@@ -13,7 +13,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "cni-cilium") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "cni-cilium") }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list . "cni-cilium") | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -47,9 +47,9 @@ spec:
   releaseName: cni-cilium
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "cni-cilium") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "cni-cilium") }}-cfg
         key: defaults
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "cni-cilium") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "cni-cilium") }}-cfg
         key: overrides
 {{- end }}

--- a/charts/cluster-addons/templates/csi-cephfs.yaml
+++ b/charts/cluster-addons/templates/csi-cephfs.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "csi-cephfs") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "csi-cephfs") }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list . "csi-cephfs") | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -38,9 +38,9 @@ spec:
   releaseName: csi-cephfs
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "csi-cephfs") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "csi-cephfs") }}-cfg
         key: defaults
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "csi-cephfs") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "csi-cephfs") }}-cfg
         key: overrides
 {{- end }}

--- a/charts/cluster-addons/templates/custom-addons.yaml
+++ b/charts/cluster-addons/templates/custom-addons.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list $ $name) }}-config
+  name: {{ include "cluster-addons.componentName" (list $ $name) }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list $ $name) | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -31,14 +31,14 @@ spec:
   releaseName: {{ $name }}
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list $ $name) }}-config
+        name: {{ include "cluster-addons.componentName" (list $ $name) }}-cfg
         key: values
 {{- else if eq $addon.kind "Manifests" }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list $ $name) }}-config
+  name: {{ include "cluster-addons.componentName" (list $ $name) }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list $ $name) | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -66,7 +66,7 @@ spec:
   releaseName: {{ $name }}
   manifestSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list $ $name) }}-config
+        name: {{ include "cluster-addons.componentName" (list $ $name) }}-cfg
 {{- else }}
 {{- printf "Unrecognised addon kind - %s" $addon.kind | fail }}
 {{- end }}

--- a/charts/cluster-addons/templates/etcd-defrag.yaml
+++ b/charts/cluster-addons/templates/etcd-defrag.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "etcd-defrag") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "etcd-defrag") }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list . "etcd-defrag") | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -30,6 +30,6 @@ spec:
   releaseName: etcd-defrag
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "etcd-defrag") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "etcd-defrag") }}-cfg
         key: overrides
 {{- end }}

--- a/charts/cluster-addons/templates/ingress-nginx.yaml
+++ b/charts/cluster-addons/templates/ingress-nginx.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "ingress-nginx") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "ingress-nginx") }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list . "ingress-nginx") | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -37,10 +37,10 @@ spec:
   releaseName: ingress-nginx
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "ingress-nginx") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "ingress-nginx") }}-cfg
         key: defaults
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "ingress-nginx") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "ingress-nginx") }}-cfg
         key: overrides
 {{- if .Values.monitoring.enabled }}
 ---

--- a/charts/cluster-addons/templates/kubernetes-dashboard.yaml
+++ b/charts/cluster-addons/templates/kubernetes-dashboard.yaml
@@ -3,9 +3,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "kubernetes-dashboard") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "k8s-dashboard") }}-cfg
   labels:
-    {{- include "cluster-addons.componentLabels" (list . "kubernetes-dashboard") | nindent 4 }}
+    {{- include "cluster-addons.componentLabels" (list . "k8s-dashboard") | nindent 4 }}
     addons.stackhpc.com/watch: ""
 stringData:
   # Enable the metrics scraper by default
@@ -18,8 +18,8 @@ stringData:
 apiVersion: addons.stackhpc.com/v1alpha1
 kind: HelmRelease
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "kubernetes-dashboard") }}
-  labels: {{ include "cluster-addons.componentLabels" (list . "kubernetes-dashboard") | nindent 4 }}
+  name: {{ include "cluster-addons.componentName" (list . "k8s-dashboard") }}
+  labels: {{ include "cluster-addons.componentLabels" (list . "k8s-dashboard") | nindent 4 }}
   annotations:
     # Tell Argo to ignore the non-controller owner references for this object
     argocd.argoproj.io/sync-options: "ControllerReferencesOnly=true"
@@ -28,12 +28,12 @@ spec:
   bootstrap: true
   chart: {{ toYaml .Values.kubernetesDashboard.chart | nindent 4 }}
   targetNamespace: {{ .Values.kubernetesDashboard.release.namespace }}
-  releaseName: kubernetes-dashboard
+  releaseName: k8s-dashboard
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "kubernetes-dashboard") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "k8s-dashboard") }}-cfg
         key: defaults
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "kubernetes-dashboard") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "k8s-dashboard") }}-cfg
         key: overrides
 {{- end }}

--- a/charts/cluster-addons/templates/mellanox-network-operator.yaml
+++ b/charts/cluster-addons/templates/mellanox-network-operator.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "mellanox-network-operator") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "mellanox-network-operator") }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list . "mellanox-network-operator") | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -65,9 +65,9 @@ spec:
   releaseName: mellanox-network-operator
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "mellanox-network-operator") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "mellanox-network-operator") }}-cfg
         key: defaults
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "mellanox-network-operator") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "mellanox-network-operator") }}-cfg
         key: overrides
 {{- end }}

--- a/charts/cluster-addons/templates/metrics-server.yaml
+++ b/charts/cluster-addons/templates/metrics-server.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "metrics-server") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "metrics-server") }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list . "metrics-server") | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -34,9 +34,9 @@ spec:
   releaseName: metrics-server
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "metrics-server") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "metrics-server") }}-cfg
         key: defaults
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "metrics-server") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "metrics-server") }}-cfg
         key: overrides
 {{- end }}

--- a/charts/cluster-addons/templates/monitoring/blackbox-exporter.yaml
+++ b/charts/cluster-addons/templates/monitoring/blackbox-exporter.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "blackbox-exporter") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "blackbox-exporter") }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list . "blackbox-exporter") | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -38,10 +38,10 @@ spec:
   releaseName: prometheus-blackbox-exporter
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "blackbox-exporter") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "blackbox-exporter") }}-cfg
         key: defaults
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "blackbox-exporter") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "blackbox-exporter") }}-cfg
         key: overrides
 ---
 apiVersion: addons.stackhpc.com/v1alpha1

--- a/charts/cluster-addons/templates/monitoring/kube-prometheus-stack.yaml
+++ b/charts/cluster-addons/templates/monitoring/kube-prometheus-stack.yaml
@@ -31,7 +31,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "kube-prometheus-stack") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "kube-prom-stack") }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list . "kube-prometheus-stack") | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -87,10 +87,10 @@ spec:
   releaseName: kube-prometheus-stack
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "kube-prometheus-stack") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "kube-prom-stack") }}-cfg
         key: defaults
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "kube-prometheus-stack") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "kube-prom-stack") }}-cfg
         key: overrides
   # StatefulSets do not allow their PVCs to be resized, but we can use lifecycle hooks to
   # ensure that it happens correctly

--- a/charts/cluster-addons/templates/monitoring/loki-stack.yaml
+++ b/charts/cluster-addons/templates/monitoring/loki-stack.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "loki-stack") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "loki-stack") }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list . "loki-stack") | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -70,10 +70,10 @@ spec:
   releaseName: loki-stack
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "loki-stack") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "loki-stack") }}-cfg
         key: defaults
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "loki-stack") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "loki-stack") }}-cfg
         key: overrides
   # StatefulSets do not allow their PVCs to be resized, but we can use lifecycle hooks
   # to ensure that it happens correctly

--- a/charts/cluster-addons/templates/nfd.yaml
+++ b/charts/cluster-addons/templates/nfd.yaml
@@ -8,7 +8,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "node-feature-discovery") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "node-feature-discovery") }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list . "node-feature-discovery") | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -57,9 +57,9 @@ spec:
   releaseName: node-feature-discovery
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "node-feature-discovery") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "node-feature-discovery") }}-cfg
         key: defaults
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "node-feature-discovery") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "node-feature-discovery") }}-cfg
         key: overrides
 {{- end }}

--- a/charts/cluster-addons/templates/node-problem-detector.yaml
+++ b/charts/cluster-addons/templates/node-problem-detector.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "node-problem-detector") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "node-problem-detector") }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list . "node-problem-detector") | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -41,9 +41,9 @@ spec:
   releaseName: node-problem-detector
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "node-problem-detector") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "node-problem-detector") }}-cfg
         key: defaults
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "node-problem-detector") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "node-problem-detector") }}-cfg
         key: overrides
 {{- end }}

--- a/charts/cluster-addons/templates/nvidia-gpu-operator.yaml
+++ b/charts/cluster-addons/templates/nvidia-gpu-operator.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "nvidia-gpu-operator") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "nvidia-gpu-operator") }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list . "nvidia-gpu-operator") | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -54,9 +54,9 @@ spec:
   releaseName: nvidia-gpu-operator
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "nvidia-gpu-operator") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "nvidia-gpu-operator") }}-cfg
         key: defaults
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "nvidia-gpu-operator") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "nvidia-gpu-operator") }}-cfg
         key: overrides
 {{- end }}

--- a/charts/cluster-addons/templates/openstack/ccm.yaml
+++ b/charts/cluster-addons/templates/openstack/ccm.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "ccm-openstack") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "ccm-os") }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list . "ccm-openstack") | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -44,9 +44,9 @@ spec:
   releaseName: ccm-openstack
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "ccm-openstack") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "ccm-os") }}-cfg
         key: defaults
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "ccm-openstack") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "ccm-os") }}-cfg
         key: overrides
 {{- end }}

--- a/charts/cluster-addons/templates/openstack/csi-cinder.yaml
+++ b/charts/cluster-addons/templates/openstack/csi-cinder.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "csi-cinder") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "csi-cinder") }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list . "csi-cinder") | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -53,10 +53,10 @@ spec:
   releaseName: csi-cinder
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "csi-cinder") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "csi-cinder") }}-cfg
         key: defaults
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "csi-cinder") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "csi-cinder") }}-cfg
         key: overrides
 {{-
   if or

--- a/charts/cluster-addons/templates/openstack/csi-manila.yaml
+++ b/charts/cluster-addons/templates/openstack/csi-manila.yaml
@@ -49,7 +49,7 @@ allowedTopologies: {{ toYaml . | nindent 2 }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "csi-manila") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "csi-manila") }}-cfg
   labels:
     {{- include "cluster-addons.componentLabels" (list . "csi-manila") | nindent 4 }}
     addons.stackhpc.com/watch: ""
@@ -91,10 +91,10 @@ spec:
   releaseName: csi-manila
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "csi-manila") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "csi-manila") }}-cfg
         key: defaults
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "csi-manila") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "csi-manila") }}-cfg
         key: overrides
 {{-
   if or

--- a/charts/cluster-addons/templates/openstack/k8s-keystone-auth.yaml
+++ b/charts/cluster-addons/templates/openstack/k8s-keystone-auth.yaml
@@ -3,9 +3,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "k8s-keystone-auth") }}-config
+  name: {{ include "cluster-addons.componentName" (list . "k8s-ksauth") }}-cfg
   labels:
-    {{- include "cluster-addons.componentLabels" (list . "k8s-keystone-auth") | nindent 4 }}
+    {{- include "cluster-addons.componentLabels" (list . "k8s-ksauth") | nindent 4 }}
     addons.stackhpc.com/watch: ""
 stringData:
   overrides: |
@@ -15,8 +15,8 @@ stringData:
 apiVersion: addons.stackhpc.com/v1alpha1
 kind: HelmRelease
 metadata:
-  name: {{ include "cluster-addons.componentName" (list . "k8s-keystone-auth") }}
-  labels: {{ include "cluster-addons.componentLabels" (list . "k8s-keystone-auth") | nindent 4 }}
+  name: {{ include "cluster-addons.componentName" (list . "k8s-ksauth") }}
+  labels: {{ include "cluster-addons.componentLabels" (list . "k8s-ksauth") | nindent 4 }}
   annotations:
     # Tell Argo to ignore the non-controller owner references for this object
     argocd.argoproj.io/sync-options: "ControllerReferencesOnly=true"
@@ -25,9 +25,9 @@ spec:
   bootstrap: true
   chart: {{ toYaml .Values.openstack.k8sKeystoneAuth.chart | nindent 4 }}
   targetNamespace: {{ .Values.openstack.k8sKeystoneAuth.targetNamespace }}
-  releaseName: k8s-keystone-auth
+  releaseName: k8s-ksauth
   valuesSources:
     - secret:
-        name: {{ include "cluster-addons.componentName" (list . "k8s-keystone-auth") }}-config
+        name: {{ include "cluster-addons.componentName" (list . "k8s-ksauth") }}-cfg
         key: overrides
 {{- end }}


### PR DESCRIPTION
Some secrets created for very long cluster names were going over the 63 char label limit of Kubernetes, and were not deploying.

Example error message:
  failureMessage: 'HelmRelease.addons.stackhpc.com "reallylongnamecluster1reallylo-oe62woigm3qq-ccm-openstack"
    is invalid: metadata.labels: Invalid value: "secret.addons.stackhpc.com/reallylongnamecluster1reallylo-oe62woigm3qq-ccm-openstack-config":
    name part must be no more than 63 characters'