### PR TITLE
update API Provider to v1beta1

### DIFF
--- a/charts/openstack-cluster/templates/cluster-openstack.yaml
+++ b/charts/openstack-cluster/templates/cluster-openstack.yaml
@@ -25,9 +25,15 @@ spec:
     {{- toYaml .manageSecurityGroups | nindent 2 }}
   {{- end }}
   {{- end }}
-  {{- with .externalNetworkId }}
+  disableExternalNetwork: {{ .disableExternalNetwork | default "false" }}
+  {{- if or .externalNetworkFilter .externalNetworkId }}
   externalNetwork:
-    id: {{ . }}
+    {{- if .externalNetworkFilter }}
+    {{- toYaml .externalNetworkFilter | nindent 2 }}
+    {{- else }}
+    id: {{ .externalNetworkId }}
+  {{- end }}
+  {{- end }}
   {{- end }}
   {{- with .internalNetwork }}
   {{- if or .networkFilter .subnetFilter }}

--- a/charts/openstack-cluster/templates/cluster-openstack.yaml
+++ b/charts/openstack-cluster/templates/cluster-openstack.yaml
@@ -11,20 +11,19 @@ metadata:
     # NOTE: Argo won't delete this object itself as it has an owner reference to the cluster
 spec:
   identityRef:
-    kind: Secret
     name: {{ include "openstack-cluster.cloudCredentialsSecretName" . }}
-  cloudName: openstack
+    cloudName: openstack
   {{- with .Values.controlPlaneEndpoint }}
   controlPlaneEndpoint: {{ toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.clusterNetworking }}
-  {{- with .dnsNameservers }}
-  dnsNameservers: {{ toYaml . | nindent 4 }}
+  {{- if .manageSecurityGroups }}
+  managedSecurityGroups: 
+    allowAllInClusterTraffic: {{ .allowAllInClusterTraffic }}
   {{- end }}
-  managedSecurityGroups: {{ .manageSecurityGroups }}
-  allowAllInClusterTraffic: {{ .allowAllInClusterTraffic }}
   {{- with .externalNetworkId }}
-  externalNetworkId: {{ . }}
+  externalNetwork:
+    id: {{ . }}
   {{- end }}
   {{- with .internalNetwork }}
   {{- if or .networkFilter .subnetFilter }}
@@ -32,10 +31,15 @@ spec:
   network: {{ . | toYaml | nindent 4 }}
   {{- end }}
   {{- with .subnetFilter }}
-  subnet: {{ . | toYaml | nindent 4 }}
+  subnets:
+    - {{ . | toYaml | nindent 4 }}
   {{- end }}
   {{- else }}
-  nodeCidr: {{ .nodeCidr }}
+  managedSubnets:
+    - cidr: {{ .nodeCidr }}
+      {{- with .dnsNameservers }}
+      dnsNameservers: {{ toYaml . | nindent 4 }}
+      {{- end }}
   {{- end }}
   {{- end }}
   {{- end }}
@@ -47,7 +51,7 @@ spec:
     provider: {{ .loadBalancerProvider }}
   {{- end }}
   {{- if .allowedCidrs }}
-    allowedCidrs:
+    allowedCIDRs:
       {{- range .allowedCidrs }}
       - {{ . }}
       {{- end}}

--- a/charts/openstack-cluster/templates/cluster-openstack.yaml
+++ b/charts/openstack-cluster/templates/cluster-openstack.yaml
@@ -19,7 +19,11 @@ spec:
   {{- with .Values.clusterNetworking }}
   {{- if .manageSecurityGroups }}
   managedSecurityGroups: 
+    {{- if eq .manageSecurityGroups "true" }}
     allowAllInClusterTraffic: {{ .allowAllInClusterTraffic }}
+    {{- else }}
+    {{- toYaml .manageSecurityGroups | nindent 2 }}
+  {{- end }}
   {{- end }}
   {{- with .externalNetworkId }}
   externalNetwork:

--- a/charts/openstack-cluster/templates/cluster-openstack.yaml
+++ b/charts/openstack-cluster/templates/cluster-openstack.yaml
@@ -18,12 +18,12 @@ spec:
   {{- end }}
   {{- with .Values.clusterNetworking }}
   {{- if .manageSecurityGroups }}
-  managedSecurityGroups: 
+  managedSecurityGroups:
     {{- if eq .manageSecurityGroups "true" }}
     allowAllInClusterTraffic: {{ .allowAllInClusterTraffic }}
     {{- else }}
     {{- toYaml .manageSecurityGroups | nindent 2 }}
-  {{- end }}
+    {{- end }}
   {{- end }}
   disableExternalNetwork: {{ .disableExternalNetwork | default "false" }}
   {{- if or .externalNetworkFilter .externalNetworkId }}
@@ -32,27 +32,33 @@ spec:
     {{- toYaml .externalNetworkFilter | nindent 2 }}
     {{- else }}
     id: {{ .externalNetworkId }}
-  {{- end }}
+    {{- end }}
   {{- end }}
   {{- end }}
   {{- with .internalNetwork }}
-  {{- if or .networkFilter .subnetFilter }}
+  {{- if or .networkFilter .subnetFilter .subnets }}
   {{- with .networkFilter }}
   network: {{ . | toYaml | nindent 4 }}
   {{- end }}
-  {{- with .subnetFilter }}
+  {{- if or .subnets .subnetFilter }}
   subnets:
-    - {{ . | toYaml | nindent 4 }}
+  {{- if .subnets }}
+  {{- toYaml .subnets | nindent 2 }}
+  {{- else }}
+  - {{ toYaml .subnetFilter | nindent 4 }}
+  {{- end }}
   {{- end }}
   {{- else }}
   managedSubnets:
-    - cidr: {{ .nodeCidr }}
-      {{- with .dnsNameservers }}
-      dnsNameservers: {{ toYaml . | nindent 4 }}
-      {{- end }}
+  {{- if .managedSubnets }}
+  {{- toYaml .managedSubnets | nindent 2 }}
+  {{- else }}
+  - cidr: {{ .nodeCidr }}
+    dnsNameservers: {{ toYaml .Values.dnsNameservers | nindent 4 }}
   {{- end }}
   {{- end }}
   {{- end }}
+
   {{- with .Values.apiServer }}
   {{- if .enableLoadBalancer }}
   apiServerLoadBalancer:
@@ -60,14 +66,13 @@ spec:
   {{- if .loadBalancerProvider }}
     provider: {{ .loadBalancerProvider }}
   {{- end }}
-  {{- if .allowedCidrs }}
+  {{- if or .allowedCidrs .allowedCIDRs }}
     allowedCIDRs:
-      {{- range .allowedCidrs }}
+      {{- range .allowedCidrs | default .allowedCIDRs }}
       - {{ . }}
       {{- end}}
   {{- end }}
   {{- end }}
-
   disableAPIServerFloatingIP: {{ not .associateFloatingIP }}
   {{- with .floatingIP }}
   apiServerFloatingIP: {{ . }}

--- a/charts/openstack-cluster/templates/cluster-openstack.yaml
+++ b/charts/openstack-cluster/templates/cluster-openstack.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackCluster
 metadata:
   name: {{ include "openstack-cluster.clusterName" . }}

--- a/charts/openstack-cluster/templates/cluster.yaml
+++ b/charts/openstack-cluster/templates/cluster.yaml
@@ -13,7 +13,7 @@ spec:
     name: {{ include "openstack-cluster.componentName" (list . "control-plane") }}
     namespace: {{ .Release.Namespace }}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: OpenStackCluster
     name: {{ include "openstack-cluster.clusterName" . }}
     namespace: {{ .Release.Namespace }}

--- a/charts/openstack-cluster/templates/control-plane/kubeadm-control-plane.yaml
+++ b/charts/openstack-cluster/templates/control-plane/kubeadm-control-plane.yaml
@@ -91,7 +91,7 @@ spec:
       labels: {{ include "openstack-cluster.componentSelectorLabels" (list . "control-plane") | nindent 8 }}
     infrastructureRef:
       kind: OpenStackMachineTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       name: {{ include "openstack-cluster.controlplane.mt.name" . }}
       namespace: {{ .Release.Namespace }}
     nodeDrainTimeout: {{ .Values.controlPlane.nodeDrainTimeout }}

--- a/charts/openstack-cluster/templates/control-plane/openstack-machine-template.yaml
+++ b/charts/openstack-cluster/templates/control-plane/openstack-machine-template.yaml
@@ -71,17 +71,21 @@ template:
               name: {{ . }}
               {{- else }}
               {{- toYaml . | nindent 14 }}
+              {{- end }}
             {{- end }}
           {{- end }}
       {{- end }}
     {{- end }}
-    {{- end }}
     {{- with .Values.controlPlane.machineNetworking.ports }}
     ports: {{ toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.controlPlane.serverGroupId }}
+    {{- if or .Values.controlPlane.serverGroupFilter .Values.serverGroupId }}
     serverGroup:
-      id: {{ . }}
+      {{- if .Values.controlPlane.serverGroupFilter }}
+      {{- toYaml .Values.controlPlane.serverGroupFilter | nindent 6 }}
+      {{- else }}
+      id: {{ .Values.serverGroupId }}
+      {{- end }}
     {{- end }}
 {{- end }}
 

--- a/charts/openstack-cluster/templates/control-plane/openstack-machine-template.yaml
+++ b/charts/openstack-cluster/templates/control-plane/openstack-machine-template.yaml
@@ -21,8 +21,23 @@ template:
     {{- if or .Values.controlPlane.machineConfigDrive $blockDevices }}
     configDrive: true
     {{- end }}
-    {{- if .Values.controlPlane.machineRootVolume.diskSize }}
-    rootVolume: {{ toYaml .Values.controlPlane.machineRootVolume | nindent 6 }}
+    {{- if or .Values.controlPlane.machineRootVolume.sizeGiB .Values.controlPlane.machineRootVolume.diskSize }}
+    rootVolume:
+      {{- with .Values.controlPlane.machineRootVolume }}
+      {{- $size := .sizeGiB | default .diskSize }}
+      sizeGiB: {{ $size }}
+      {{- $type := .type | default .volumeType }}
+      type: {{ $type }}
+      {{- with .blockDevice.availabilityZone }}
+      availabilityZone:
+        {{- if kindIs "string" . }}
+        name: {{ . }}
+        {{- else }}
+        {{- toYaml . | nindent 6 }}
+        {{- end }}
+      {{- end }}
+      {{- omit . "sizeGiB" "diskSize" "availabilityZone" "Type" "volumeType" | toYaml | nindent 6 }}
+      {{- end }}
     {{- end }}
     image:
       {{- if .Values.controlPlane.machineImageId }}
@@ -51,10 +66,15 @@ template:
             type: {{ . }}
             {{- end }}
             {{- with $blockDevice.availabilityZone }}
-            availabilityZone: {{toYaml . | nindent 14 }}
+            availabilityZone:
+              {{- if kindIs "string" . }}
+              name: {{ . }}
+              {{- else }}
+              {{- toYaml . | nindent 14 }}
             {{- end }}
           {{- end }}
       {{- end }}
+    {{- end }}
     {{- end }}
     {{- with .Values.controlPlane.machineNetworking.ports }}
     ports: {{ toYaml . | nindent 6 }}

--- a/charts/openstack-cluster/templates/control-plane/openstack-machine-template.yaml
+++ b/charts/openstack-cluster/templates/control-plane/openstack-machine-template.yaml
@@ -12,9 +12,8 @@
 template:
   spec:
     identityRef:
-      kind: Secret
       name: {{ include "openstack-cluster.cloudCredentialsSecretName" . }}
-    cloudName: openstack
+      cloudName: openstack
     flavor: {{ .Values.controlPlane.machineFlavor | required ".Values.controlPlane.machineFlavor is required" }}
     {{- with .Values.machineSSHKeyName }}
     sshKeyName: {{ . }}
@@ -25,17 +24,20 @@ template:
     {{- if .Values.controlPlane.machineRootVolume.diskSize }}
     rootVolume: {{ toYaml .Values.controlPlane.machineRootVolume | nindent 6 }}
     {{- end }}
-    {{- if .Values.controlPlane.machineImageId }}
-    imageUUID: {{ .Values.controlPlane.machineImageId }}
-    {{- else if .Values.controlPlane.machineImage }}
-    image: {{ tpl .Values.controlPlane.machineImage . }}
-    {{- else if .Values.machineImageId }}
-    imageUUID: {{ .Values.machineImageId }}
-    {{- else if .Values.machineImage }}
-    image: {{ tpl .Values.machineImage . }}
-    {{- else }}
-    {{- fail "Either controlPlane.machineImageId, controlPlane.machineImage, machineImage or machineImageId is required" }}
-    {{- end }}
+    image:
+      {{- if .Values.controlPlane.machineImageId }}
+      id: {{ .Values.controlPlane.machineImageId }}
+      {{- else if .Values.controlPlane.machineImage }}
+      filter:
+        name: {{ tpl .Values.controlPlane.machineImage . }}
+      {{- else if .Values.machineImageId }}
+      id: {{ .Values.machineImageId }}
+      {{- else if .Values.machineImage }}
+      filter:
+        name: {{ tpl .Values.machineImage . }}
+      {{- else }}
+      {{- fail "Either controlPlane.machineImageId, controlPlane.machineImage, machineImage or machineImageId is required" }}
+      {{- end }}
     {{- with $blockDevices }}
     additionalBlockDevices:
       {{- range $name, $blockDevice := . }}
@@ -49,7 +51,7 @@ template:
             type: {{ . }}
             {{- end }}
             {{- with $blockDevice.availabilityZone }}
-            availabilityZone: {{ . }}
+            availabilityZone: {{toYaml . | nindent 14 }}
             {{- end }}
           {{- end }}
       {{- end }}
@@ -58,7 +60,8 @@ template:
     ports: {{ toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.controlPlane.serverGroupId }}
-    serverGroupID: {{ . }}
+    serverGroup:
+      id: {{ . }}
     {{- end }}
 {{- end }}
 

--- a/charts/openstack-cluster/templates/control-plane/openstack-machine-template.yaml
+++ b/charts/openstack-cluster/templates/control-plane/openstack-machine-template.yaml
@@ -71,7 +71,7 @@ template:
 {{- include "openstack-cluster.componentName" (list . "control-plane") }}-{{ trunc 8 $checksum }}
 {{- end }}
 
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
   name: {{ include "openstack-cluster.controlplane.mt.name" . }}

--- a/charts/openstack-cluster/templates/node-group/machine-deployment.yaml
+++ b/charts/openstack-cluster/templates/node-group/machine-deployment.yaml
@@ -62,7 +62,7 @@ spec:
           kind: KubeadmConfigTemplate
           name: {{ include "openstack-cluster.nodegroup.kct.name" (list $ $nodeGroup) }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: OpenStackMachineTemplate
         name: {{ include "openstack-cluster.nodegroup.mt.name" (list $ $nodeGroup) }}
       nodeDrainTimeout: {{ $nodeGroup.nodeDrainTimeout }}

--- a/charts/openstack-cluster/templates/node-group/openstack-machine-template.yaml
+++ b/charts/openstack-cluster/templates/node-group/openstack-machine-template.yaml
@@ -72,7 +72,7 @@ template:
 {{- range $nodeGroupOverrides := .Values.nodeGroups }}
 {{- $nodeGroup := deepCopy $.Values.nodeGroupDefaults | mustMerge $nodeGroupOverrides }}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha7
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: OpenStackMachineTemplate
 metadata:
   name: {{ include "openstack-cluster.nodegroup.mt.name" (list $ $nodeGroup) }}

--- a/charts/openstack-cluster/templates/node-group/openstack-machine-template.yaml
+++ b/charts/openstack-cluster/templates/node-group/openstack-machine-template.yaml
@@ -17,8 +17,23 @@ template:
     {{- if or $nodeGroup.machineConfigDrive $nodeGroup.additionalBlockDevices }}
     configDrive: true
     {{- end }}
-    {{- if $nodeGroup.machineRootVolume.diskSize }}
-    rootVolume: {{ toYaml $nodeGroup.machineRootVolume | nindent 6 }}
+    {{- if or $nodeGroup.machineRootVolume.sizeGiB $nodeGroup.machineRootVolume.diskSize }}
+    rootVolume:
+      {{- with $nodeGroup.controlPlane.machineRootVolume }}
+      {{- $size := .sizeGiB | default .diskSize }}
+      sizeGiB: {{ $size }}
+      {{- $type := .type | default .volumeType }}
+      type: {{ $type }}
+      {{- with .blockDevice.availabilityZone }}
+      availabilityZone:
+        {{- if kindIs "string" . }}
+        name: {{ . }}
+        {{- else }}
+        {{- toYaml . | nindent 6 }}
+        {{- end }}
+      {{- end }}
+      {{- omit . "sizeGiB" "diskSize" "availabilityZone" "Type" "volumeType" | toYaml | nindent 6 }}
+      {{- end }}
     {{- end }}
     image:
       {{- if $nodeGroup.machineImageId }}
@@ -47,7 +62,12 @@ template:
             type: {{ . }}
             {{- end }}
             {{- with $blockDevice.availabilityZone }}
-            availabilityZone: {{toYaml . | nindent 14 }}
+            availabilityZone:
+              {{- if kindIs "string" . }}
+              name: {{ . }}
+              {{- else }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
             {{- end }}
           {{- end }}
       {{- end }}

--- a/charts/openstack-cluster/templates/node-group/openstack-machine-template.yaml
+++ b/charts/openstack-cluster/templates/node-group/openstack-machine-template.yaml
@@ -8,9 +8,8 @@
 template:
   spec:
     identityRef:
-      kind: Secret
       name: {{ include "openstack-cluster.cloudCredentialsSecretName" $ctx }}
-    cloudName: openstack
+      cloudName: openstack
     flavor: {{ $nodeGroup.machineFlavor | required (printf "no flavor specified for node group '%s'" $nodeGroup.name) }}
     {{- with $ctx.Values.machineSSHKeyName }}
     sshKeyName: {{ . }}
@@ -21,17 +20,20 @@ template:
     {{- if $nodeGroup.machineRootVolume.diskSize }}
     rootVolume: {{ toYaml $nodeGroup.machineRootVolume | nindent 6 }}
     {{- end }}
-    {{- if $nodeGroup.machineImageId }}
-    imageUUID: {{ $nodeGroup.machineImageId }}
-    {{- else if $nodeGroup.machineImage }}
-    image: {{ tpl $nodeGroup.machineImage $ctx }}
-    {{- else if $ctx.Values.machineImageId }}
-    imageUUID: {{ $ctx.Values.machineImageId }}
-    {{- else if $ctx.Values.machineImage }}
-    image: {{ tpl $ctx.Values.machineImage $ctx }}
-    {{- else }}
-    {{- fail "Either nodeGroupDefaults.machineImageId, nodeGroupDefaults.machineImage, machineImageId or machineImage is required" }}
-    {{- end }}
+    image:
+      {{- if $nodeGroup.machineImageId }}
+      id: {{ $nodeGroup.machineImageId }}
+      {{- else if $nodeGroup.machineImage }}
+      filter:
+        name: {{ tpl $nodeGroup.machineImage $ctx }}
+      {{- else if $ctx.Values.machineImageId }}
+      id: {{ $ctx.Values.machineImageId }}
+      {{- else if $ctx.Values.machineImage }}
+      filter:
+        name: {{ tpl $ctx.Values.machineImage $ctx }}
+      {{- else }}
+      {{- fail "Either nodeGroupDefaults.machineImageId, nodeGroupDefaults.machineImage, machineImageId or machineImage is required" }}
+      {{- end }}
     {{- with $nodeGroup.additionalBlockDevices }}
     additionalBlockDevices:
       {{- range $name, $blockDevice := . }}
@@ -45,7 +47,7 @@ template:
             type: {{ . }}
             {{- end }}
             {{- with $blockDevice.availabilityZone }}
-            availabilityZone: {{ . }}
+            availabilityZone: {{toYaml . | nindent 14 }}
             {{- end }}
           {{- end }}
       {{- end }}
@@ -54,7 +56,8 @@ template:
     ports: {{ toYaml . | nindent 6 }}
     {{- end }}
     {{- with $nodeGroup.serverGroupId }}
-    serverGroupID: {{ . }}
+    serverGroup:
+      id: {{ . }}
     {{- end }}
 {{- end }}
 

--- a/charts/openstack-cluster/templates/node-group/openstack-machine-template.yaml
+++ b/charts/openstack-cluster/templates/node-group/openstack-machine-template.yaml
@@ -75,9 +75,13 @@ template:
     {{- with $nodeGroup.machineNetworking.ports }}
     ports: {{ toYaml . | nindent 6 }}
     {{- end }}
-    {{- with $nodeGroup.serverGroupId }}
+    {{- if or $nodeGroup.serverGroupFilter $nodeGroup.serverGroupId }}
     serverGroup:
-      id: {{ . }}
+      {{- if $nodeGroup.serverGroupFilter }}
+      {{- toYaml $nodeGroup.serverGroupFilter | nindent 6 }}
+      {{- else }}
+      id: {{ $nodeGroup.serverGroupId }}
+      {{- end }}
     {{- end }}
 {{- end }}
 

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -47,13 +47,31 @@ kubeNetwork:
 # Settings for the OpenStack networking for the cluster
 clusterNetworking:
   # Custom nameservers to use for the hosts
-  dnsNameservers:
   # Indicates if security groups should be managed by the cluster
-  manageSecurityGroups: true
-  # Indicates if the managed security groups should allow all in-cluster traffic
-  # The default CNI installed by the addons is Cilium, so this is true by default
-  allowAllInClusterTraffic: true
-  # The ID of the external network to use
+  # Its possible to add additional rules to the managed security groups 
+  # https://cluster-api-openstack.sigs.k8s.io/api/v1beta1/api#infrastructure.cluster.x-k8s.io/v1beta1.ManagedSecurityGroups
+  managedSecurityGroups: 
+    # Indicates if the managed security groups should allow all in-cluster traffic
+    # The default CNI installed by the addons is Cilium, so this is true by default
+    allowAllInClusterTraffic: true
+
+    # Add additional security group like so:
+    # allNodesSecurityGroupRules:
+    # - remoteManagedGroups:
+    # - controlplane
+    # - worker
+    # direction: ingress
+    # etherType: IPv4
+    # name: BGP (Calico)
+    # portRangeMin: 179
+    # portRangeMax: 179
+    # protocol: tcp
+    # description: "Allow BGP between control plane and workers"
+
+  # DEPRECATED fields see above
+  # manageSecurityGroups: true
+  # allowAllInClusterTraffic: true
+
   # If not given, the external network will be detected
   externalNetworkId:
   # Details of the internal network to use
@@ -348,7 +366,7 @@ nodeGroupDefaults:
     #   name: az1
 
     # diskSize: DEPRECATED - use sizeGiB
-
+    
   # The ID of the server group to use for machines in the node group
   serverGroupId:
   # Labels to apply to the node objects in Kubernetes that correspond to machines in the node group

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -136,6 +136,7 @@ etcd:
     # # The volume availability zone to use
     # # If not specified, the machine availability zone is used
     # availabilityZone:
+    #   name: az1
 
 # Settings for the Kubernetes API server
 apiServer:
@@ -196,15 +197,19 @@ controlPlane:
     ports:
   # The root volume spec for control plane machines
   machineRootVolume:
-    # The size of the disk to use
+    # The size of the disk to use in gibibytes (GiB)
     # If not given, the ephemeral root disk from the flavor is used
-    diskSize:
+    sizeGiB:
     # The volume type to use
     # If not specified, the default volume type is used
     # volumeType:
     # The volume availability zone to use
     # If not specified, the machine availability zone is used
     # availabilityZone:
+    #   name: az1
+
+    # diskSize: DEPRECATED - use sizeGiB
+
   # The ID of the server group to use for control plane machines
   serverGroupId:
   # Labels to apply to the node objects in Kubernetes that correspond to control plane machines
@@ -228,6 +233,7 @@ controlPlane:
     #   # The volume availability zone to use
     #   # If not specified, the machine availability zone is used
     #   availabilityZone:
+    #     name: az1
   # Indicates whether control plane machines should use config drive or not
   machineConfigDrive: false
   # The time to wait for a node to finish draining before it can be removed
@@ -330,15 +336,19 @@ nodeGroupDefaults:
     ports:
   # The root volume spec for machines in the node group
   machineRootVolume:
-    # The size of the disk to use
+    # The size of the disk to use in gibibytes (GiB)
     # If not given, the ephemeral root disk from the flavor is used
-    diskSize:
+    sizeGiB:
     # The volume type to use
     # If not specified, the default volume type is used
     # volumeType:
     # The volume availability zone to use
     # If not specified, the machine availability zone is used
     # availabilityZone:
+    #   name: az1
+
+    # diskSize: DEPRECATED - use sizeGiB
+
   # The ID of the server group to use for machines in the node group
   serverGroupId:
   # Labels to apply to the node objects in Kubernetes that correspond to machines in the node group

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -256,8 +256,15 @@ controlPlane:
 
     # diskSize: DEPRECATED - use sizeGiB
 
+  # Details of the server group to use for control plane machines
+  serverGroupFilter:
+    # id: 
+    # name: 
+
+  # DEPRECATED - use serverGroupFilter 
   # The ID of the server group to use for control plane machines
-  serverGroupId:
+  # serverGroupId:
+
   # Labels to apply to the node objects in Kubernetes that correspond to control plane machines
   nodeLabels:
     # my.company.org/label: value
@@ -395,8 +402,15 @@ nodeGroupDefaults:
 
     # diskSize: DEPRECATED - use sizeGiB
     
+  # Details of the server group to use for machines in the node group
+  serverGroupFilter:
+    # id: 
+    # name: 
+
+  # DEPRECATED - use serverGroupFilter 
   # The ID of the server group to use for machines in the node group
-  serverGroupId:
+  # serverGroupId:
+
   # Labels to apply to the node objects in Kubernetes that correspond to machines in the node group
   # By default, nodes get the label "capi.stackhpc.com/node-group=<node group name>"
   nodeLabels:

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -72,7 +72,18 @@ clusterNetworking:
   # manageSecurityGroups: true
   # allowAllInClusterTraffic: true
 
+  # Indicates whether or not to attempt to connect the cluster to an external network
+  disableExternalNetwork: false 
+
+  # Details of the external network to use 
+  # This option is ignored if disableExternalNetwork is set to true.
   # If not given, the external network will be detected
+  externalNetworkFilter:
+    # id: e63ca1a0-f69d-4fbf-b306-310857b1afe5
+    # name: tenant-external-net
+
+  # The ID of the external network to use 
+  # DEPRECATED - use externalNetwork 
   externalNetworkId:
   # Details of the internal network to use
   internalNetwork:

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -46,7 +46,7 @@ kubeNetwork:
 
 # Settings for the OpenStack networking for the cluster
 clusterNetworking:
-  # Custom nameservers to use for the hosts
+
   # Indicates if security groups should be managed by the cluster
   # Its possible to add additional rules to the managed security groups 
   # https://cluster-api-openstack.sigs.k8s.io/api/v1beta1/api#infrastructure.cluster.x-k8s.io/v1beta1.ManagedSecurityGroups
@@ -93,13 +93,30 @@ clusterNetworking:
       # id: e63ca1a0-f69d-4fbf-b306-310857b1afe5
       # name: tenant-internal-net
     # See Cluster API documentation for details
-    # NOTE: can only specify one subnet for now
+    
+    # Filter to find existing subnets to use 
+    # allows specification of two existing subnets for the dual-stack scenario.
+    subnets:
+      # - id: e63ca1a0-f69d-4fbf-b306-31089s1j38d8
+
+    # DEPRECATED - use subnets
     subnetFilter:
       # id: e63ca1a0-f69d-4fbf-b306-31089s1j38d8
       # name: tenant-internal-subnet
-    # The CIDR to use if creating a cluster network
+    
+    # ManagedSubnets describe OpenStack Subnets to be created.
     # This is only used if neither of networkFilter and subnetFilter are given
-    nodeCidr: 192.168.3.0/24
+    managedSubnets:
+      - cidr: 192.168.3.0/24
+        # Custom nameservers to use for the hosts
+        dnsNameservers: 
+
+    # DEPRECATED - set in managedSubnets above
+    # nodeCidr: 192.168.3.0/24
+
+  # DEPRECATED - set in internalNetwork.managedSubnets 
+  # dnsNameservers: 
+
 
 # Settings for registry mirrors
 # When a mirror is set, it will be tried for images but will fall back to the
@@ -174,7 +191,7 @@ apiServer:
   # Indicates what loadbalancer provider to use. Default is amphora
   loadBalancerProvider:
   # Restrict loadbalancer access to select IPs
-  # allowedCidrs
+  # allowedCIDRs 
   #  - 192.168.0.0/16  # needed for cluster to init
   #  - 10.10.0.0/16  # IPv4 Internal Network
   #  - 123.123.123.123 # some other IPs

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -63,8 +63,8 @@ clusterNetworking:
     networkFilter:
       # id: e63ca1a0-f69d-4fbf-b306-310857b1afe5
       # name: tenant-internal-net
-    # Filter to find an existing subnet for the cluster internal network
     # See Cluster API documentation for details
+    # NOTE: can only specify one subnet for now
     subnetFilter:
       # id: e63ca1a0-f69d-4fbf-b306-31089s1j38d8
       # name: tenant-internal-subnet


### PR DESCRIPTION
An attempt to fix issue https://github.com/azimuth-cloud/capi-helm-charts/issues/398

update api provider to use v1beta1 since its provided in newest cluster api provider version 0.10.* 
