### PR TITLE
check if cri registry is already defined before setting it

### DIFF
--- a/charts/openstack-cluster/templates/_helpers.tpl
+++ b/charts/openstack-cluster/templates/_helpers.tpl
@@ -210,15 +210,6 @@ files:
       # This file is created by the capi-helm-chart to ensure that its parent directory exists
     owner: root:root
     permissions: "0644"
-{{- if ne .Values.osDistro "flatcar" }}
-  - path: /etc/containerd/config.toml
-    content: |
-      [plugins."io.containerd.grpc.v1.cri".registry]
-      config_path = "/etc/containerd/certs.d"
-    owner: root:root
-    permissions: "0644"
-    append: true
-{{- end }}
 {{- with .Values.registryMirrors }}
 {{- range $registry, $registrySpec := . }}
   - path: /etc/containerd/certs.d/{{ $registry }}/hosts.toml
@@ -236,6 +227,17 @@ files:
         key: "auth.toml"
     owner: root:root
     permissions: "0644"
+{{- end }}
+{{- if ne .Values.osDistro "flatcar" }}
+preKubeadmCommands: 
+  - |
+      bash -s <<EOF
+      grep -q '[plugins."io.containerd.grpc.v1.cri".registry]' /etc/containerd/config.toml && exit
+      cat <<CONTENT >> /etc/containerd/config.toml
+      [plugins."io.containerd.grpc.v1.cri".registry]
+        config_path = "/etc/containerd/certs.d"
+      CONTENT
+      EOF
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
There was an update made to the upstream k8s image builder - https://github.com/kubernetes-sigs/image-builder/blob/v0.1.34/images/capi/ansible/roles/containerd/templates/etc/containerd/config.toml#L14-L15

Which means that this setting was not needed - but to enable backwards compatibility we check if the containerd config file already contains the value before setting it
