### PR TITLE
added note about using SOURCE_IP_PORT for the lb-method with OVN

### DIFF
--- a/charts/openstack-cluster/README.md
+++ b/charts/openstack-cluster/README.md
@@ -286,7 +286,9 @@ nodeGroupDefaults:
 If the target cloud uses the
 [OVN Octavia driver](https://docs.openstack.org/ovn-octavia-provider/latest/admin/driver.html),
 Kubernetes clusters should be configured to use OVN for any load-balancers that are created,
-either by Cluster API or by the OpenStack Cloud Controller Manager for `LoadBalancer` services:
+either by Cluster API or by the OpenStack Cloud Controller Manager for `LoadBalancer` services.
+In addition, lb-method must be set to `SOURCE_IP_PORT`, as the OVN provder does not support the
+default `ROUND_ROBIN`:
 
 ```yaml
 apiServer:
@@ -297,6 +299,7 @@ addons:
     cloudConfig:
       LoadBalancer:
         lb-provider: ovn
+        lb-method: SOURCE_IP_PORT
 ```
 
 ## Cluster addons


### PR DESCRIPTION
The docs currently provide configuration for using the OVN load-balancer provider, but the default lb-method provided by CCM is `ROUND_ROBIN`, which is not compatible with OVN based load balancers.   When attempting to use OVN with `ROUND_ROBIN`, CCM will error with:
`"Provider 'ovn' does not support a requested option: OVN provider does not support ROUND_ROBIN algorithm"`