### PR TITLE
Drop requirement for project ID field in cloud credentials

### DIFF
--- a/.github/values/arcus/base.yaml
+++ b/.github/values/arcus/base.yaml
@@ -1,7 +1,5 @@
 clouds:
   arcus:
-    auth:
-      project_id: f0dc9cb312144d0aa44037c9149d2513
     verify: false
 
 clusterNetworking:

--- a/.github/values/leafcloud/base.yaml
+++ b/.github/values/leafcloud/base.yaml
@@ -1,7 +1,5 @@
 clouds:
   leafcloud:
-    auth:
-      project_id: f39848421b2747148400ad8eeae8d536
     verify: false
 
 clusterNetworking:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,2 @@
 # Default owner for all files unless otherwise specified
 *  @mkjpryor
-
-# Tyler looks after the CI, so make him a code owner on CI-related files as well
-/.github/  @mkjpryor @scrungus
-ci/. @mkjpryor @scrungus

--- a/charts/openstack-cluster/README.md
+++ b/charts/openstack-cluster/README.md
@@ -108,16 +108,11 @@ For ease of use, this chart is written so that a `clouds.yaml` file can be given
 to the chart as a configuration file. When an application credential is created in Horizon,
 the corresponding `clouds.yaml` file can be downloaded, and should look something like this:
 
-> [!WARNING]
-> The Cluster API OpenStack provider currently requires that the `project_id` is present,
-> which you will need to add manually.
-
 ```yaml
 clouds:
   openstack:
     auth:
       auth_url: https://my.cloud:5000
-      project_id: "<project id>"
       application_credential_id: "<app cred id>"
       application_credential_secret: "<app cred secret>"
     region_name: "RegionOne"

--- a/charts/openstack-cluster/templates/secret-cloud-config.yaml
+++ b/charts/openstack-cluster/templates/secret-cloud-config.yaml
@@ -1,9 +1,6 @@
 {{- if not .Values.cloudCredentialsSecretName }}
 {{- if .Values.clouds }}
 {{- $cloud := index .Values.clouds .Values.cloudName }}
-{{- if not (dig "auth" "project_id" nil $cloud) }}
-{{- fail "clouds.yaml must contain the project ID" }}
-{{- end }}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Looks like this was fixed upstream at some point since the Gophercloud [type definition](https://github.com/gophercloud/gophercloud/blob/master/openstack/config/clouds/types.go#L86) now allows the project ID to be omitted.