### PR TITLE
Allow OCCM to manage LB security groups

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,2 @@
 # Default owner for all files unless otherwise specified
-*  @mkjpryor
-
-# Tyler looks after the CI, so make him a code owner on CI-related files as well
-/.github/  @mkjpryor @scrungus
-ci/. @mkjpryor @scrungus
+*  @azimuth-cloud/azimuth-core-maintainers

--- a/charts/cluster-addons/values.yaml
+++ b/charts/cluster-addons/values.yaml
@@ -74,6 +74,8 @@ openstack:
     # By default, ignore volume AZs for Cinder as most clouds have a single globally-attachable Cinder AZ
     BlockStorage:
       ignore-volume-az: true
+    LoadBalancer:
+      manage-security-groups: true
   # Settings for the Cloud Controller Manager (CCM)
   ccm:
     # Indicates if the OpenStack CCM should be enabled


### PR DESCRIPTION
Workaround for https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/2333