### PR TITLE
Revert "Allow OCCM to manage LB security groups (#469)"

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,2 @@
 # Default owner for all files unless otherwise specified
-*  @mkjpryor
-
-# Tyler looks after the CI, so make him a code owner on CI-related files as well
-/.github/  @mkjpryor @scrungus
-ci/. @mkjpryor @scrungus
+*  @azimuth-cloud/azimuth-core-maintainers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,6 @@
 # Default owner for all files unless otherwise specified
-*  @azimuth-cloud/azimuth-core-maintainers
+*  @mkjpryor
+
+# Tyler looks after the CI, so make him a code owner on CI-related files as well
+/.github/  @mkjpryor @scrungus
+ci/. @mkjpryor @scrungus

--- a/charts/cluster-addons/values.yaml
+++ b/charts/cluster-addons/values.yaml
@@ -74,8 +74,6 @@ openstack:
     # By default, ignore volume AZs for Cinder as most clouds have a single globally-attachable Cinder AZ
     BlockStorage:
       ignore-volume-az: true
-    LoadBalancer:
-      manage-security-groups: true
   # Settings for the Cloud Controller Manager (CCM)
   ccm:
     # Indicates if the OpenStack CCM should be enabled


### PR DESCRIPTION
It turns out that the OpenStack cloud-controller-manager is not very good at managing security groups, particularly when cluster nodes are deleted and recreated. We've decided that a better solution for now is to revert this and instead pin CAPO to an older working version.