### PR TITLE
Enable OCCM-managed LB security groups

### DIFF
--- a/charts/cluster-addons/values.yaml
+++ b/charts/cluster-addons/values.yaml
@@ -74,6 +74,8 @@ openstack:
     # By default, ignore volume AZs for Cinder as most clouds have a single globally-attachable Cinder AZ
     BlockStorage:
       ignore-volume-az: true
+    LoadBalancer:
+      manage-security-groups: true
   # Settings for the Cloud Controller Manager (CCM)
   ccm:
     # Indicates if the OpenStack CCM should be enabled


### PR DESCRIPTION
The previous issues we were seeing with OCCM-managed security groups for OVN LBs were fixed in https://github.com/kubernetes/cloud-provider-openstack/pull/2705 so we can reinstate this fix. Unfortunately OCCM CI is currently broken which means the Helm repos don't have chart version 2.31.2 (which contains the bug fix) available yet so will mark this as DNM for now. I've raised the Helm repo issue in the Kubernetes provider-openstack Slack channel but no timeline yet for fixing their CI.