### PR TITLE
Update dnsNameservers context to pick up values

### DIFF
--- a/charts/openstack-cluster/templates/cluster-openstack.yaml
+++ b/charts/openstack-cluster/templates/cluster-openstack.yaml
@@ -36,7 +36,7 @@ spec:
   {{- else }}
   managedSubnets:
     - cidr: {{ .nodeCidr }}
-      {{- with .dnsNameservers }}
+      {{- with (default $.Values.clusterNetworking.dnsNameservers .dnsNameservers) }}
       dnsNameservers: {{ toYaml . | nindent 8 }}
       {{- end }}
   {{- end }}

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -73,7 +73,8 @@ kubeNetwork:
 # Settings for the OpenStack networking for the cluster
 clusterNetworking:
   # Custom nameservers to use for the hosts
-  dnsNameservers:
+  # Deprecated; use `clusterNetworking.internalNetwork.dnsNameservers` instead.
+  # dnsNameservers: []
   # Indicates if security groups should be managed by the cluster
   manageSecurityGroups: true
   # Indicates if the managed security groups should allow all in-cluster traffic
@@ -97,6 +98,9 @@ clusterNetworking:
     # The CIDR to use if creating a cluster network
     # This is only used if neither of networkFilter and subnetFilter are given
     nodeCidr: 192.168.3.0/24
+    # List of nameserver IPs to use when creating a cluster network.
+    # This is only used if neither of networkFilter and subnetFilter are given
+    dnsNameservers:
 
 # Settings for registry mirrors
 # When a mirror is set, it will be tried for images but will fall back to the


### PR DESCRIPTION
The `dnsNameservers` value has moved into `managedSubnets` section, but was trying to reference `.internalNetwork.dnsNameservers` which does not exist in chart values.

This change removes the context switch into `internalNetwork` to allow all references to correctly find their related values.

Closes: https://github.com/azimuth-cloud/capi-helm-charts/issues/476