### PR TITLE
Update OpenStackCluster with v1beta1 case and omitempty.

### DIFF
--- a/charts/openstack-cluster/templates/cluster-openstack.yaml
+++ b/charts/openstack-cluster/templates/cluster-openstack.yaml
@@ -51,13 +51,15 @@ spec:
     provider: {{ .loadBalancerProvider }}
     {{- end }}
     {{- if .allowedCidrs }}
-    allowedCidrs:
+    allowedCIDRs:
       {{- range .allowedCidrs }}
       - {{ . }}
       {{- end}}
     {{- end }}
   {{- end }}
-  disableAPIServerFloatingIP: {{ not .associateFloatingIP }}
+  {{- if not .associateFloatingIP }}
+  disableAPIServerFloatingIP: true
+  {{- end }}
   {{- with .floatingIP }}
   apiServerFloatingIP: {{ . }}
   {{- end }}


### PR DESCRIPTION
These changes match resource changes in CAPO and allow tools such as ArgoCD to fully synchronize the resource instead of showing minor changes. No functionality is changed.

* disableAPIServerFloatingIP is now `omitempty`[1], and is therefore absent when querying the resource when set to 'false'.
* `allowedCidrs` becomes `allowedCIDRs` [2]

[1] https://github.com/kubernetes-sigs/cluster-api-provider-openstack/commit/9223883df61151215286df3442ee1c29a1590c38
[2] https://cluster-api-openstack.sigs.k8s.io/topics/crd-changes/v1alpha7-to-v1beta1#changes-to-ports