### PR TITLE
Bump upload-artifact action to v4

### DIFF
--- a/.github/actions/upgrade-and-test/action.yml
+++ b/.github/actions/upgrade-and-test/action.yml
@@ -77,7 +77,7 @@ runs:
     # However, in some cases the cluster will never become unready, e.g.
     # in the chart upgrade tests if there are no changes to templates
     # In this case, we time out after 2m which should be enough time for
-    # the controllers to react
+    # the controllers to react
     - name: Wait for cluster not ready
       shell: bash
       run: |-
@@ -152,7 +152,7 @@ runs:
       if: "${{ inputs.sonobuoy-upload == 'yes' }}"
 
     - name: Upload sonobuoy results artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: sonobuoy-results-${{ inputs.name }}
         path: ./sonobuoy-results-${{ inputs.name }}.tar.gz

--- a/.github/actions/upload-logs/action.yml
+++ b/.github/actions/upload-logs/action.yml
@@ -22,7 +22,7 @@ runs:
         kubectl -n capi-janitor-system logs deploy/cluster-api-janitor-openstack > capi-janitor-openstack-logs.txt
 
     - name: Upload controller log artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cluster-api-controller-logs-${{ inputs.name-suffix }}
         path: ./*-logs.txt


### PR DESCRIPTION
Fixes failing CI due to https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/