### PR TITLE
Prepend default to GlobalNetPolicy manifest name

### DIFF
--- a/charts/cluster-addons/templates/cni/calico.yaml
+++ b/charts/cluster-addons/templates/cni/calico.yaml
@@ -70,7 +70,7 @@ spec:
         apiVersion: projectcalico.org/v3
         kind: GlobalNetworkPolicy
         metadata:
-          name: {{ include "cluster-addons.componentName" (list . "deny-egress") }}
+          name: default.{{ include "cluster-addons.componentName" (list . "deny-egress") }}
         spec:
           order: {{ .Values.cni.calico.globalNetworkPolicy.denyPriority }}
           namespaceSelector: {{ .Values.cni.calico.globalNetworkPolicy.denyNamespaceSelector }}
@@ -95,7 +95,7 @@ spec:
         apiVersion: projectcalico.org/v3
         kind: GlobalNetworkPolicy
         metadata:
-          name: {{ include "cluster-addons.componentName" (list . "allow-global-egress") }}
+          name: default.{{ include "cluster-addons.componentName" (list . "allow-global-egress") }}
         spec:
           order: {{ .Values.cni.calico.globalNetworkPolicy.allowPriority }}
           types:


### PR DESCRIPTION
The manifest source targets {{ cluster-name }}, however the Calico operator creates a GlobalNetworkPolicy on the child with default.{{ cluster-name}}. 
This works fine until there's a diff, then the manifest will fail to apply/patch because K8s requires a delete and recreate for name changes.

I suspect default comes from the tier automatically applied by the operator: `projectcalico.org/tier=default`

We've seen some clusters which have sat retrying for 20K+ attempts, but because the update is usually an annotation the cluster continues fine, so it's probably been missed for a while. I've also tested this on a fresh cluster, and it still deploys with the correct resource name in the child (i.e. it doesn't become `default.default.{cluster-name}...`)

To test:
- Deploy a cluster without this change
- On the management cluster edit `manifests/{cluster-name}-cni-calico-globalnetpolicy` and change the order from 10 to 20 for example
- Notice how it will now fail and retry again and again
- Apply the fix from this PR to the manifest, it will reconcile and continue