### PR TITLE
Add node group name validation during templating

### DIFF
--- a/charts/openstack-cluster/templates/node-group/machine-deployment.yaml
+++ b/charts/openstack-cluster/templates/node-group/machine-deployment.yaml
@@ -1,5 +1,8 @@
 {{- range $nodeGroupOverrides := .Values.nodeGroups }}
 {{- $nodeGroup := deepCopy $.Values.nodeGroupDefaults | mustMerge $nodeGroupOverrides }}
+{{- if not (regexMatch "^[a-z][a-z0-9\\-]+[a-z0-9]$" $nodeGroup.name) }}
+{{ fail (printf "Node group name must be at least three characters long and must contain only lower-case alphanumeric characters and dashes (found name: %s)" $nodeGroup.name) }}
+{{- end -}}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment


### PR DESCRIPTION
Example templating errors:

Invalid character:
```
% helm template test charts/openstack-cluster -f values-test.yml --set "nodeGroups[0].name=abc.d"
Error: execution error at (openstack-cluster/templates/node-group/machine-deployment.yaml:4:3): Node group name must be at least three characters long and must contain only lower-case alphanumeric characters and dashes (found name: abc.d)
```

Name too short:
```
% helm template test charts/openstack-cluster -f values-test.yml --set "nodeGroups[0].name=ab"
Error: execution error at (openstack-cluster/templates/node-group/machine-deployment.yaml:4:3): Node group name must be at least three characters long and must contain only lower-case alphanumeric characters and dashes (found name: ab)
```