### PR TITLE
Fix metrics server pod disruption budget config

### DIFF
--- a/charts/cluster-addons/templates/metrics-server.yaml
+++ b/charts/cluster-addons/templates/metrics-server.yaml
@@ -14,7 +14,7 @@ stringData:
     # Since we deploy in kube-system, we need a PDB to allow eviction to happen
     podDisruptionBudget:
       enabled: true
-      minAvailable: 0
+      maxUnavailable: 1
   overrides: |
     {{- toYaml .Values.metricsServer.release.values | nindent 4 }}
 ---


### PR DESCRIPTION
The existing PDB config uses `minAvailable: 0` but since the metrics-server Helm chart uses an `if` conditional [here](https://github.com/kubernetes-sigs/metrics-server/blob/master/charts/metrics-server/templates/pdb.yaml#L10) it means that the Helm conditional evaluates to `false` and we end up with a PDB created with no explicit disruption spec defined. Kubernetes then interprets this as no disruptions allowed to the deployment:
```
% kubectl get pdb -n kube-system
NAME             MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
metrics-server   N/A             N/A               0                     3h1m
```
which is the exact opposite of the intended effect (as per Matt's original comment in the Helm template).

The end result of this is that nodes which are running the single metrics server pod get marked for drain during an upgrade but the metrics server pod can never be evicted so the node is never successfully drained. This means that CAPI just waits for the node deletion timeout (defined [here](https://github.com/azimuth-cloud/capi-helm-charts/blob/main/charts/openstack-cluster/values.yaml#L285) and then forcefully deletes the node.