### PR TITLE
Remove api-server cloud provider flag

### DIFF
--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -314,9 +314,6 @@ controlPlane:
     # controller-manager, scheduler and kube-proxy to 0.0.0.0 so that Prometheus can reach
     # them to collect metrics
     clusterConfiguration:
-      apiServer:
-        extraArgs:
-          cloud-provider: external
       controllerManager:
         extraArgs:
           cloud-provider: external


### PR DESCRIPTION
It has been the default since 1.29
And it was removed in k8s 1.33.0
https://github.com/kubernetes/kubernetes/pull/130162/files