### PR TITLE
Fix whitespace in node group name check

### DIFF
--- a/charts/openstack-cluster/templates/node-group/machine-deployment.yaml
+++ b/charts/openstack-cluster/templates/node-group/machine-deployment.yaml
@@ -1,8 +1,8 @@
 {{- range $nodeGroupOverrides := .Values.nodeGroups }}
 {{- $nodeGroup := deepCopy $.Values.nodeGroupDefaults | mustMerge $nodeGroupOverrides }}
 {{- if not (regexMatch "^[a-z][a-z0-9\\-]+[a-z0-9]$" $nodeGroup.name) }}
-{{ fail (printf "Node group name must be at least three characters long and must contain only lower-case alphanumeric characters and dashes (found name: %s)" $nodeGroup.name) }}
-{{- end -}}
+{{- fail (printf "Node group name must be at least three characters long and must contain only lower-case alphanumeric characters and dashes (found name: %s)" $nodeGroup.name) }}
+{{- end }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment


### PR DESCRIPTION
Previous version lead to a mangled `helm template` output when two or more node groups were specified.

Old template output included:
```
      nodeDeletionTimeout: 5m0s---
apiVersion: cluster.x-k8s.io/v1beta1
kind: MachineDeployment
```

fixed version templates correctly as:
```
      nodeDeletionTimeout: 5m0s
---
# Source: openstack-cluster/templates/node-group/machine-deployment.yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: MachineDeployment
```