### PR TITLE
Disable CI approval for internal contributors

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - name: Workflow approved
         run: exit 0
+    if: ${{ github.repository != 'azimuth-cloud/capi-helm-charts' }}
 
   lint:
     needs: [wait_for_approval]


### PR DESCRIPTION
Avoids need to approve CI for contributors who already have write access to the repo