### PR TITLE
Added GPU plugin images to Intel dependencies

### DIFF
--- a/.github/workflows/update-addons.yml
+++ b/.github/workflows/update-addons.yml
@@ -71,6 +71,8 @@ jobs:
 
           - key: intel-device-plugin-gpu
             path: intelDevicePlugin.gpuPlugin.chart
+            additional-images: |-
+              docker.io/intel/intel-gpu-plugin:{0}
 
           - key: intel-device-plugin-operator
             path: intelDevicePlugin.operator.chart


### PR DESCRIPTION
The Intel GPU plugin Helm chart only deploys CRDs which refer to its associated image in a non-standard location, so an additional images field is necessary