### PR TITLE
Fix bug in DNS nameserver values

### DIFF
--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -72,8 +72,6 @@ kubeNetwork:
 
 # Settings for the OpenStack networking for the cluster
 clusterNetworking:
-  # Custom nameservers to use for the hosts
-  dnsNameservers:
   # Indicates if security groups should be managed by the cluster
   manageSecurityGroups: true
   # Indicates if the managed security groups should allow all in-cluster traffic
@@ -97,6 +95,8 @@ clusterNetworking:
     # The CIDR to use if creating a cluster network
     # This is only used if neither of networkFilter and subnetFilter are given
     nodeCidr: 192.168.3.0/24
+    # List of nameservers to add to managed subnet
+    dnsNameservers:
 
 # Settings for registry mirrors
 # When a mirror is set, it will be tried for images but will fall back to the


### PR DESCRIPTION
The DNS nameservers option was in the wrong place in the values.yml file, where it should have been in the internal network block: https://github.com/azimuth-cloud/capi-helm-charts/blob/65c92d45fd76db299bb318e46377cd03107dff53/charts/openstack-cluster/templates/cluster-openstack.yaml#L27-L40
