### PR TITLE
Switch to from bitnami/kubectl to rancher/kubectl image

### DIFF
--- a/charts/etcd-defrag/templates/cronjob.yaml
+++ b/charts/etcd-defrag/templates/cronjob.yaml
@@ -23,9 +23,8 @@ spec:
           containers:
             - name: {{ .Chart.Name }}
               image: {{
-                .Values.image.tag |
-                  default (printf "%s.%s" .Capabilities.KubeVersion.Major .Capabilities.KubeVersion.Minor) |
                   printf "%s:%s" .Values.image.repository
+                  (default .Capabilities.KubeVersion.Version .Values.image.tag)
               }}
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               # We run the defrag by execing into one of the etcd pods

--- a/charts/etcd-defrag/values.yaml
+++ b/charts/etcd-defrag/values.yaml
@@ -10,7 +10,7 @@ activeDeadlineSeconds: 3600
 
 # The kubectl image to use
 image:
-  repository: bitnami/kubectl
+  repository: rancher/kubectl
   pullPolicy: IfNotPresent
   tag: ""  # Defaults to the Kubernetes minor version, e.g. 1.28
 

--- a/charts/openstack-cluster/tests/__snapshot__/snapshot_base_test.yaml.snap
+++ b/charts/openstack-cluster/tests/__snapshot__/snapshot_base_test.yaml.snap
@@ -813,7 +813,7 @@ templated manifests should match snapshot:
             owner: root:root
             path: /etc/containerd/certs.d/.keepdir
             permissions: "0644"
-          - content: |2
+          - content: |
               server = "https://registry-1.docker.io"
               [host."https://quay.io/v2/azimuth/docker.io"]
               capabilities = ["pull", "resolve"]
@@ -822,7 +822,7 @@ templated manifests should match snapshot:
             owner: root:root
             path: /etc/containerd/certs.d/docker.io/hosts.toml
             permissions: "0644"
-          - content: |2
+          - content: |
               server = "https://ghcr.io"
               [host."https://quay.io/v2/azimuth/ghcr.io"]
               capabilities = ["pull", "resolve"]
@@ -831,7 +831,7 @@ templated manifests should match snapshot:
             owner: root:root
             path: /etc/containerd/certs.d/ghcr.io/hosts.toml
             permissions: "0644"
-          - content: |2
+          - content: |
               server = "https://nvcr.io"
               [host."https://quay.io/v2/azimuth/nvcr.io"]
               capabilities = ["pull", "resolve"]
@@ -840,7 +840,7 @@ templated manifests should match snapshot:
             owner: root:root
             path: /etc/containerd/certs.d/nvcr.io/hosts.toml
             permissions: "0644"
-          - content: |2
+          - content: |
               server = "https://quay.io"
               [host."https://quay.io/v2/azimuth/quay.io"]
               capabilities = ["pull", "resolve"]
@@ -849,7 +849,7 @@ templated manifests should match snapshot:
             owner: root:root
             path: /etc/containerd/certs.d/quay.io/hosts.toml
             permissions: "0644"
-          - content: |2
+          - content: |
               server = "https://registry.k8s.io"
               [host."https://quay.io/v2/azimuth/registry.k8s.io"]
               capabilities = ["pull", "resolve"]
@@ -1005,7 +1005,7 @@ templated manifests should match snapshot:
               owner: root:root
               path: /etc/containerd/certs.d/.keepdir
               permissions: "0644"
-            - content: |2
+            - content: |
                 server = "https://registry-1.docker.io"
                 [host."https://quay.io/v2/azimuth/docker.io"]
                 capabilities = ["pull", "resolve"]
@@ -1014,7 +1014,7 @@ templated manifests should match snapshot:
               owner: root:root
               path: /etc/containerd/certs.d/docker.io/hosts.toml
               permissions: "0644"
-            - content: |2
+            - content: |
                 server = "https://ghcr.io"
                 [host."https://quay.io/v2/azimuth/ghcr.io"]
                 capabilities = ["pull", "resolve"]
@@ -1023,7 +1023,7 @@ templated manifests should match snapshot:
               owner: root:root
               path: /etc/containerd/certs.d/ghcr.io/hosts.toml
               permissions: "0644"
-            - content: |2
+            - content: |
                 server = "https://nvcr.io"
                 [host."https://quay.io/v2/azimuth/nvcr.io"]
                 capabilities = ["pull", "resolve"]
@@ -1032,7 +1032,7 @@ templated manifests should match snapshot:
               owner: root:root
               path: /etc/containerd/certs.d/nvcr.io/hosts.toml
               permissions: "0644"
-            - content: |2
+            - content: |
                 server = "https://quay.io"
                 [host."https://quay.io/v2/azimuth/quay.io"]
                 capabilities = ["pull", "resolve"]
@@ -1041,7 +1041,7 @@ templated manifests should match snapshot:
               owner: root:root
               path: /etc/containerd/certs.d/quay.io/hosts.toml
               permissions: "0644"
-            - content: |2
+            - content: |
                 server = "https://registry.k8s.io"
                 [host."https://quay.io/v2/azimuth/registry.k8s.io"]
                 capabilities = ["pull", "resolve"]

--- a/charts/openstack-cluster/tests/__snapshot__/snapshot_full_test.yaml.snap
+++ b/charts/openstack-cluster/tests/__snapshot__/snapshot_full_test.yaml.snap
@@ -2140,7 +2140,7 @@ templated manifests should match snapshot:
             owner: root:root
             path: /etc/containerd/certs.d/.keepdir
             permissions: "0644"
-          - content: |2
+          - content: |
               server = "https://registry-1.docker.io"
               [host."https://quay.io/v2/azimuth/docker.io"]
               capabilities = ["pull", "resolve"]
@@ -2149,7 +2149,7 @@ templated manifests should match snapshot:
             owner: root:root
             path: /etc/containerd/certs.d/docker.io/hosts.toml
             permissions: "0644"
-          - content: |2
+          - content: |
               server = "https://ghcr.io"
               [host."https://quay.io/v2/azimuth/ghcr.io"]
               capabilities = ["pull", "resolve"]
@@ -2158,7 +2158,7 @@ templated manifests should match snapshot:
             owner: root:root
             path: /etc/containerd/certs.d/ghcr.io/hosts.toml
             permissions: "0644"
-          - content: |2
+          - content: |
               server = "https://nvcr.io"
               [host."https://quay.io/v2/azimuth/nvcr.io"]
               capabilities = ["pull", "resolve"]
@@ -2167,7 +2167,7 @@ templated manifests should match snapshot:
             owner: root:root
             path: /etc/containerd/certs.d/nvcr.io/hosts.toml
             permissions: "0644"
-          - content: |2
+          - content: |
               server = "https://quay.io"
               [host."https://quay.io/v2/azimuth/quay.io"]
               capabilities = ["pull", "resolve"]
@@ -2176,7 +2176,7 @@ templated manifests should match snapshot:
             owner: root:root
             path: /etc/containerd/certs.d/quay.io/hosts.toml
             permissions: "0644"
-          - content: |2
+          - content: |
               server = "https://registry.k8s.io"
               [host."https://quay.io/v2/azimuth/registry.k8s.io"]
               capabilities = ["pull", "resolve"]
@@ -2332,7 +2332,7 @@ templated manifests should match snapshot:
               owner: root:root
               path: /etc/containerd/certs.d/.keepdir
               permissions: "0644"
-            - content: |2
+            - content: |
                 server = "https://registry-1.docker.io"
                 [host."https://quay.io/v2/azimuth/docker.io"]
                 capabilities = ["pull", "resolve"]
@@ -2341,7 +2341,7 @@ templated manifests should match snapshot:
               owner: root:root
               path: /etc/containerd/certs.d/docker.io/hosts.toml
               permissions: "0644"
-            - content: |2
+            - content: |
                 server = "https://ghcr.io"
                 [host."https://quay.io/v2/azimuth/ghcr.io"]
                 capabilities = ["pull", "resolve"]
@@ -2350,7 +2350,7 @@ templated manifests should match snapshot:
               owner: root:root
               path: /etc/containerd/certs.d/ghcr.io/hosts.toml
               permissions: "0644"
-            - content: |2
+            - content: |
                 server = "https://nvcr.io"
                 [host."https://quay.io/v2/azimuth/nvcr.io"]
                 capabilities = ["pull", "resolve"]
@@ -2359,7 +2359,7 @@ templated manifests should match snapshot:
               owner: root:root
               path: /etc/containerd/certs.d/nvcr.io/hosts.toml
               permissions: "0644"
-            - content: |2
+            - content: |
                 server = "https://quay.io"
                 [host."https://quay.io/v2/azimuth/quay.io"]
                 capabilities = ["pull", "resolve"]
@@ -2368,7 +2368,7 @@ templated manifests should match snapshot:
               owner: root:root
               path: /etc/containerd/certs.d/quay.io/hosts.toml
               permissions: "0644"
-            - content: |2
+            - content: |
                 server = "https://registry.k8s.io"
                 [host."https://quay.io/v2/azimuth/registry.k8s.io"]
                 capabilities = ["pull", "resolve"]
@@ -2422,7 +2422,7 @@ templated manifests should match snapshot:
               owner: root:root
               path: /etc/containerd/certs.d/.keepdir
               permissions: "0644"
-            - content: |2
+            - content: |
                 server = "https://registry-1.docker.io"
                 [host."https://quay.io/v2/azimuth/docker.io"]
                 capabilities = ["pull", "resolve"]
@@ -2431,7 +2431,7 @@ templated manifests should match snapshot:
               owner: root:root
               path: /etc/containerd/certs.d/docker.io/hosts.toml
               permissions: "0644"
-            - content: |2
+            - content: |
                 server = "https://ghcr.io"
                 [host."https://quay.io/v2/azimuth/ghcr.io"]
                 capabilities = ["pull", "resolve"]
@@ -2440,7 +2440,7 @@ templated manifests should match snapshot:
               owner: root:root
               path: /etc/containerd/certs.d/ghcr.io/hosts.toml
               permissions: "0644"
-            - content: |2
+            - content: |
                 server = "https://nvcr.io"
                 [host."https://quay.io/v2/azimuth/nvcr.io"]
                 capabilities = ["pull", "resolve"]
@@ -2449,7 +2449,7 @@ templated manifests should match snapshot:
               owner: root:root
               path: /etc/containerd/certs.d/nvcr.io/hosts.toml
               permissions: "0644"
-            - content: |2
+            - content: |
                 server = "https://quay.io"
                 [host."https://quay.io/v2/azimuth/quay.io"]
                 capabilities = ["pull", "resolve"]
@@ -2458,7 +2458,7 @@ templated manifests should match snapshot:
               owner: root:root
               path: /etc/containerd/certs.d/quay.io/hosts.toml
               permissions: "0644"
-            - content: |2
+            - content: |
                 server = "https://registry.k8s.io"
                 [host."https://quay.io/v2/azimuth/registry.k8s.io"]
                 capabilities = ["pull", "resolve"]

--- a/skopeo-manifests/etcd-defrag.yaml
+++ b/skopeo-manifests/etcd-defrag.yaml
@@ -1,7 +1,6 @@
+# TODO: Add automation to keep this file up to date
 docker.io:
   images:
-    bitnami/kubectl:
-    - "1.30"
-    - "1.31"
-    - "1.32"
-    - "1.33"
+    rancher/kubectl:
+    - "v1.33.5"
+    - "v1.34.1"


### PR DESCRIPTION
Bitnami recently paywalled their image updates so we need another source. Unfortunately there doesn't seem to be anyone else who publishes tags without the k8s patch version appended to allow us to always use the latest patch version, so we have to default to the full semver tag instead.