### PR TITLE
Add Helm values schema to all charts

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,11 +32,22 @@ jobs:
             --all \
             --validate-maintainers=false
 
-      - name: Run template validation (current values)
-        run: |-
+      - name: Run template validation with base values
+        run: |
+          set -eo pipefail
           helm template foo charts/openstack-cluster \
-            -f charts/openstack-cluster/tests/values_base.yaml \
-            -f charts/openstack-cluster/tests/values_full.yaml \
+            -f charts/openstack-cluster/tests/base-values.yaml \
+            | docker run -i --rm ghcr.io/yannh/kubeconform:latest \
+            --strict --summary \
+            --schema-location default \
+            --schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+            --skip HelmRelease,Manifests,OpenStackCluster,OpenStackMachineTemplate
+
+      - name: Run template validation with full values
+        run: |
+          set -eo pipefail
+          helm template foo charts/openstack-cluster \
+            -f charts/openstack-cluster/tests/full-values.yaml \
             | docker run -i --rm ghcr.io/yannh/kubeconform:latest \
             --strict --summary \
             --schema-location default \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,77 @@
 # Contributing
 
+## Making a contribution
+
 We welcome contributions and suggestions for improvements to these Helm charts.
 Please check for relevant issues and PRs before opening a new one of your own.
 
-## Making a contribution
+The remainder of this document describes some of the tooling that is used for testing
+and validation in this repo. Prospective contributors should read the relevant sections
+carefully in order to make the contribution process as easy and efficient as possible.
 
-### Helm template snapshots
+## Helm values schema
+
+The charts in this repository use Helm's JSON schema validation functionality to improve user
+experience and catch basic formatting errors in Helm values files. The JSON schema are
+generated using the [helm-schema](https://github.com/dadav/helm-schema) plugin and each chart's
+default values.yaml file is annotated with various `@schema` comment blocks where the schema
+generator is unable to infer the an appropriate schema from the default values alone.
+
+When making changes to a chart's values.yaml file, the schema plugin will need to be installed
+locally by following the [installation instructions](https://github.com/dadav/helm-schema?tab=readme-ov-file#installation)
+and the chart schema will need to be updated by running `helm schema` (or `helm-schema` /
+`docker run ...` depending on the installation method chosen). If a chart's values file format
+is updated without regenerating the schema, the CI linting and templating checks will fail.
+
+### Schema strictness
+
+The generated schema is not intended to be as strict as possible. Instead, it is intentionally
+vague in certain places to avoid being overly restrictive on the set of allowed config values;
+this is particularly important when the provided config values are passed along to an external
+system. For example, the OpenStack cloud credentials field is annotated as a generic object
+rather than attempting to specify the exact schema for an OpenStack clouds.yaml file, since
+this could feasibly change in future OpenStack versions:
+
+```yaml
+# Content for the clouds.yaml file
+# @schema
+# type: [object,null]
+# @schema
+clouds:
+```
+
+Similarly, fields which default to an empty map are constrained based on the kinds of values
+which a chart consumer may choose to provide. For example, the `machineMetadata`
+field is only constrained to be a generic object, since the user may wish to provide arbitrary
+Kubernetes metadata here:
+
+```yaml
+# Global metadata items to add to each machine
+# @schema
+# additionalProperties: true
+# @schema
+machineMetadata: {}
+```
+
+In contrast, the `clusterAnnotations` field is constrained to a list of key-value pairs where
+both keys and values must be strings, since Kubernetes only allows string values for resource
+annotations:
+
+```yaml
+# Any extra annotations to add to the cluster
+# @schema
+# type: object
+# patternProperties:
+#   ".*":
+#     type: string
+# @schema
+clusterAnnotations: {}
+```
+
+A full list of the available schema annotations can be found on the Helm schema plugin's
+[README](https://github.com/dadav/helm-schema?tab=readme-ov-file#annotations).
+
+## Helm template snapshots
 
 The CI in this repository uses the Helm [unittest](https://github.com/helm-unittest/helm-unittest)
 plugin's snapshotting functionality to check PRs for changes to the templated manifests.

--- a/charts/cluster-addons/values.schema.json
+++ b/charts/cluster-addons/values.schema.json
@@ -2,6 +2,61 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
   "properties": {
+    "amdGPUOperator": {
+      "additionalProperties": false,
+      "properties": {
+        "chart": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "default": "gpu-operator-charts",
+              "title": "name",
+              "type": "string"
+            },
+            "repo": {
+              "default": "https://rocm.github.io/gpu-operator",
+              "title": "repo",
+              "type": "string"
+            },
+            "version": {
+              "default": "v1.5.0",
+              "title": "version",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "chart",
+          "type": "object"
+        },
+        "enabled": {
+          "default": false,
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "release": {
+          "additionalProperties": false,
+          "properties": {
+            "namespace": {
+              "default": "kube-amd-gpu",
+              "title": "namespace",
+              "type": "string"
+            },
+            "values": {
+              "additionalProperties": false,
+              "required": [],
+              "title": "values",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "release",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "amdGPUOperator",
+      "type": "object"
+    },
     "certManager": {
       "additionalProperties": false,
       "properties": {
@@ -1549,63 +1604,6 @@
       },
       "required": [],
       "title": "nodeProblemDetector",
-      "type": "object"
-    },
-    "amdGPUOperator": {
-      "additionalProperties": false,
-      "description": "Settings for the AMD GPU operator",
-      "properties": {
-        "chart": {
-          "additionalProperties": false,
-          "properties": {
-            "name": {
-              "default": "gpu-operator-charts",
-              "title": "name",
-              "type": "string"
-            },
-            "repo": {
-              "default": "https://rocm.github.io/gpu-operator",
-              "title": "repo",
-              "type": "string"
-            },
-            "version": {
-              "default": "v1.4.1",
-              "title": "version",
-              "type": "string"
-            }
-          },
-          "required": [],
-          "title": "chart",
-          "type": "object"
-        },
-        "enabled": {
-          "default": true,
-          "description": "Indicates if the AMD GPU operator should be enabled\nNote that because it uses node feature discovery to run only on nodes\nwith an AMD GPU available, the overhead of enabling this on clusters\nthat do not need it now but may need it in the future is low",
-          "title": "enabled",
-          "type": "boolean"
-        },
-        "release": {
-          "additionalProperties": false,
-          "properties": {
-            "namespace": {
-              "default": "kube-amd-gpu",
-              "title": "namespace",
-              "type": "string"
-            },
-            "values": {
-              "additionalProperties": true,
-              "properties": {},
-              "required": [],
-              "title": "values"
-            }
-          },
-          "required": [],
-          "title": "release",
-          "type": "object"
-        }
-      },
-      "required": [],
-      "title": "amdGPUOperator",
       "type": "object"
     },
     "nvidiaGPUOperator": {

--- a/charts/cluster-addons/values.schema.json
+++ b/charts/cluster-addons/values.schema.json
@@ -1,0 +1,2246 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "certManager": {
+      "additionalProperties": false,
+      "properties": {
+        "chart": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "default": "cert-manager",
+              "title": "name",
+              "type": "string"
+            },
+            "repo": {
+              "default": "https://charts.jetstack.io",
+              "title": "repo",
+              "type": "string"
+            },
+            "version": {
+              "default": "v1.17.0",
+              "title": "version",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "chart",
+          "type": "object"
+        },
+        "enabled": {
+          "default": false,
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "release": {
+          "additionalProperties": false,
+          "properties": {
+            "namespace": {
+              "default": "cert-manager",
+              "title": "namespace",
+              "type": "string"
+            },
+            "values": {
+              "additionalProperties": true,
+              "properties": {
+                "crds": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": {
+                      "default": true,
+                      "title": "enabled",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [],
+                  "title": "crds",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "values"
+            }
+          },
+          "required": [],
+          "title": "release",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "certManager",
+      "type": "object"
+    },
+    "clusterName": {
+      "default": "",
+      "description": "The name of the Cluster API cluster\nif not given, the release name is used",
+      "required": [],
+      "title": "clusterName",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "cni": {
+      "additionalProperties": false,
+      "description": "Settings for the CNI addon",
+      "properties": {
+        "calico": {
+          "additionalProperties": false,
+          "description": "Settings for the calico CNI\nSee https://projectcalico.docs.tigera.io/getting-started/kubernetes/helm",
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "tigera-operator",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://projectcalico.docs.tigera.io/charts",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "v3.31.5",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "globalNetworkPolicy": {
+              "additionalProperties": false,
+              "description": "Nova metadata service\nSee https://docs.openstack.org/nova/latest/user/metadata.html#the-metadata-service",
+              "properties": {
+                "allowEgressCidrs": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "required": []
+                  },
+                  "title": "allowEgressCidrs",
+                  "type": "array"
+                },
+                "allowPriority": {
+                  "default": 20,
+                  "title": "allowPriority",
+                  "type": "integer"
+                },
+                "allowv6EgressCidrs": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "required": []
+                  },
+                  "title": "allowv6EgressCidrs",
+                  "type": "array"
+                },
+                "denyEgressCidrs": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "required": []
+                  },
+                  "title": "denyEgressCidrs",
+                  "type": "array"
+                },
+                "denyNamespaceSelector": {
+                  "default": "kubernetes.io/metadata.name != 'openstack-system'",
+                  "title": "denyNamespaceSelector",
+                  "type": "string"
+                },
+                "denyPriority": {
+                  "default": 10,
+                  "title": "denyPriority",
+                  "type": "integer"
+                },
+                "denyv6EgressCidrs": {
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "required": []
+                  },
+                  "title": "denyv6EgressCidrs",
+                  "type": "array"
+                }
+              },
+              "required": [],
+              "title": "globalNetworkPolicy",
+              "type": "object"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "tigera-operator",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "nodeSelector": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "node-role.kubernetes.io/control-plane": {
+                          "default": "",
+                          "title": "node-role.kubernetes.io/control-plane",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "nodeSelector",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "values"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "calico",
+          "type": "object"
+        },
+        "cilium": {
+          "additionalProperties": false,
+          "description": "Settings for the Cilium CNI\nSee https://docs.cilium.io/en/stable/gettingstarted/k8s-install-helm/ for details",
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "cilium",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://helm.cilium.io/",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "1.19.3",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "kube-system",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": true,
+                  "required": [],
+                  "title": "values"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "cilium",
+          "type": "object"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Indicates if a CNI should be deployed",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "type": {
+          "default": "calico",
+          "description": "The CNI to deploy - supported values are calico or cilium",
+          "enum": [
+            "calico",
+            "cilium"
+          ],
+          "required": [],
+          "title": "type"
+        }
+      },
+      "required": [],
+      "title": "cni",
+      "type": "object"
+    },
+    "csi": {
+      "additionalProperties": false,
+      "description": "Settings for CSI addons",
+      "properties": {
+        "cephfs": {
+          "additionalProperties": false,
+          "description": "Settings for the CephFS CSI",
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "ceph-csi-cephfs",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://ceph.github.io/csi-charts",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "3.11.0",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "enabled": {
+              "default": false,
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "csi-ceph-system",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": true,
+                  "required": [],
+                  "title": "values"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "cephfs",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "csi",
+      "type": "object"
+    },
+    "custom": {
+      "additionalProperties": false,
+      "description": "Settings for any custom addons",
+      "patternProperties": {
+        ".*": {
+          "oneOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "const": "HelmRelease",
+                  "required": []
+                },
+                "spec": {
+                  "properties": {
+                    "chart": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "repo": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "type": "object"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "values": {
+                      "additionalProperties": true,
+                      "required": [],
+                      "type": "object"
+                    }
+                  },
+                  "required": []
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "const": "Manifests",
+                  "required": []
+                },
+                "spec": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "manifests": {
+                      "patternProperties": {
+                        ".*": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "type": "object"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "type": "object"
+            }
+          ],
+          "required": []
+        }
+      },
+      "required": [],
+      "title": "custom",
+      "type": "object"
+    },
+    "enabled": {
+      "default": true,
+      "description": "Included for schema validation purposes.\nHas no effect unless this chart is used\nas a conditional dependency of the\nopenstack-cluster chart.",
+      "title": "enabled",
+      "type": "boolean"
+    },
+    "etcdDefrag": {
+      "additionalProperties": false,
+      "description": "Settings for etcd defragmentation jobs",
+      "properties": {
+        "chart": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "default": "etcd-defrag",
+              "title": "name",
+              "type": "string"
+            },
+            "repo": {
+              "default": "https://azimuth-cloud.github.io/capi-helm-charts",
+              "title": "repo",
+              "type": "string"
+            },
+            "version": {
+              "default": "",
+              "required": [],
+              "title": "version",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [],
+          "title": "chart",
+          "type": "object"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Indicates if the etcd defragmentation job should be enabled",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "release": {
+          "additionalProperties": false,
+          "properties": {
+            "namespace": {
+              "default": "kube-system",
+              "description": "This should be namespace in which the etcd pods are deployed",
+              "title": "namespace",
+              "type": "string"
+            },
+            "values": {
+              "additionalProperties": true,
+              "required": [],
+              "title": "values"
+            }
+          },
+          "required": [],
+          "title": "release",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "etcdDefrag",
+      "type": "object"
+    },
+    "global": {
+      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+      "required": [],
+      "title": "global",
+      "type": "object"
+    },
+    "ingress": {
+      "additionalProperties": false,
+      "description": "Settings for ingress controllers",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Indicates if ingress controllers should be enabled",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "nginx": {
+          "additionalProperties": false,
+          "description": "Settings for the Nginx ingress controller\nhttps://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx#configuration",
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "ingress-nginx",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://kubernetes.github.io/ingress-nginx",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "4.15.1",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "enabled": {
+              "default": false,
+              "description": "Indicates if the Nginx ingress controller should be enabled",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "ingress-nginx",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": true,
+                  "required": [],
+                  "title": "values"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "nginx",
+          "type": "object"
+        },
+        "traefik": {
+          "additionalProperties": false,
+          "description": "Settings for the Traefik ingress controller\nhttps://github.com/traefik/traefik-helm-chart/blob/master/EXAMPLES.md",
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "traefik",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://traefik.github.io/charts",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "40.1.0",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "enabled": {
+              "default": true,
+              "description": "Indicates if the Traefik ingress controller should be enabled\nThe Traefik ingress controller is enabled by default if ingress controllers are enabled",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "traefik",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": false,
+                  "required": [],
+                  "title": "values",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "traefik",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "ingress",
+      "type": "object"
+    },
+    "intelDevicePlugin": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "default": false,
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "gpuPlugin": {
+          "additionalProperties": false,
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "intel-device-plugins-gpu",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://intel.github.io/helm-charts",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "0.32.0",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "intel",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "enableMonitoring": {
+                      "default": true,
+                      "title": "enableMonitoring",
+                      "type": "boolean"
+                    },
+                    "logLevel": {
+                      "default": 4,
+                      "title": "logLevel",
+                      "type": "integer"
+                    },
+                    "preferredAllocationPolicy": {
+                      "default": "none",
+                      "title": "preferredAllocationPolicy",
+                      "type": "string"
+                    },
+                    "sharedDevNum": {
+                      "default": 1,
+                      "title": "sharedDevNum",
+                      "type": "integer"
+                    },
+                    "tolerations": {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "effect": {
+                                "default": "NoSchedule",
+                                "title": "effect",
+                                "type": "string"
+                              },
+                              "key": {
+                                "default": "gpu.intel.com/i915",
+                                "title": "key",
+                                "type": "string"
+                              },
+                              "operator": {
+                                "default": "Exists",
+                                "title": "operator",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "operator",
+                              "effect"
+                            ],
+                            "type": "object"
+                          }
+                        ],
+                        "required": []
+                      },
+                      "title": "tolerations",
+                      "type": "array"
+                    }
+                  },
+                  "required": [],
+                  "title": "values"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "gpuPlugin",
+          "type": "object"
+        },
+        "operator": {
+          "additionalProperties": false,
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "intel-device-plugins-operator",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://intel.github.io/helm-charts",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "0.32.0",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "intel",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "manager": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "devices": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "gpu": {
+                              "default": true,
+                              "title": "gpu",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [],
+                          "title": "devices",
+                          "type": "object"
+                        }
+                      },
+                      "required": [],
+                      "title": "manager",
+                      "type": "object"
+                    },
+                    "resources": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "limits": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "cpu": {
+                              "default": "100m",
+                              "title": "cpu",
+                              "type": "string"
+                            },
+                            "memory": {
+                              "default": "200Mi",
+                              "title": "memory",
+                              "type": "string"
+                            }
+                          },
+                          "required": [],
+                          "title": "limits",
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "cpu": {
+                              "default": "100m",
+                              "title": "cpu",
+                              "type": "string"
+                            },
+                            "memory": {
+                              "default": "160Mi",
+                              "title": "memory",
+                              "type": "string"
+                            }
+                          },
+                          "required": [],
+                          "title": "requests",
+                          "type": "object"
+                        }
+                      },
+                      "required": [],
+                      "title": "resources",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "values"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "operator",
+          "type": "object"
+        },
+        "xpuManagerMonitoring": {
+          "additionalProperties": false,
+          "description": "xpuManagerMonitoring requires Flux CD source\nand kustomization controllers to be installed\non the CAPI management cluster.",
+          "properties": {
+            "enabled": {
+              "default": true,
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "namespace": {
+              "default": "intel",
+              "title": "namespace",
+              "type": "string"
+            },
+            "repo": {
+              "additionalProperties": false,
+              "properties": {
+                "tag": {
+                  "default": "V1.2.39",
+                  "title": "tag",
+                  "type": "string"
+                },
+                "url": {
+                  "default": "https://github.com/intel/xpumanager",
+                  "title": "url",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "repo",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "xpuManagerMonitoring",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "intelDevicePlugin",
+      "type": "object"
+    },
+    "mellanoxNetworkOperator": {
+      "additionalProperties": false,
+      "description": "Settings for the Mellanox network operator",
+      "properties": {
+        "chart": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "default": "network-operator",
+              "title": "name",
+              "type": "string"
+            },
+            "repo": {
+              "default": "https://helm.ngc.nvidia.com/nvidia",
+              "title": "repo",
+              "type": "string"
+            },
+            "version": {
+              "default": "26.1.1",
+              "title": "version",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "chart",
+          "type": "object"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Indicates if the network operator should be enabled\nNote that because it uses node feature discovery to run only on nodes\nwith a Mellanox NIC available, the overhead of enabling this on clusters\nthat do not need it now but may need it in the future is low",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "release": {
+          "additionalProperties": false,
+          "properties": {
+            "namespace": {
+              "default": "network-operator",
+              "title": "namespace",
+              "type": "string"
+            },
+            "values": {
+              "additionalProperties": true,
+              "required": [],
+              "title": "values"
+            }
+          },
+          "required": [],
+          "title": "release",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "mellanoxNetworkOperator",
+      "type": "object"
+    },
+    "metricsServer": {
+      "additionalProperties": false,
+      "description": "Settings for the metrics server\nhttps://github.com/kubernetes-sigs/metrics-server#helm-chart",
+      "properties": {
+        "chart": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "default": "metrics-server",
+              "title": "name",
+              "type": "string"
+            },
+            "repo": {
+              "default": "https://kubernetes-sigs.github.io/metrics-server",
+              "title": "repo",
+              "type": "string"
+            },
+            "version": {
+              "default": "3.13.0",
+              "title": "version",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "chart",
+          "type": "object"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Indicates if the metrics server should be deployed",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "release": {
+          "additionalProperties": false,
+          "properties": {
+            "namespace": {
+              "default": "kube-system",
+              "title": "namespace",
+              "type": "string"
+            },
+            "values": {
+              "additionalProperties": true,
+              "required": [],
+              "title": "values"
+            }
+          },
+          "required": [],
+          "title": "release",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "metricsServer",
+      "type": "object"
+    },
+    "monitoring": {
+      "additionalProperties": false,
+      "description": "Settings for cluster monitoring",
+      "properties": {
+        "blackboxExporter": {
+          "additionalProperties": false,
+          "description": "Configuration for the blackbox exporter",
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "prometheus-blackbox-exporter",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://prometheus-community.github.io/helm-charts",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "11.9.1",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "enabled": {
+              "default": true,
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "openstackAuthUrlTarget": {
+              "additionalProperties": false,
+              "description": "Example of adding additional scrape targets\nserviceMonitor:\n  targets:\n    - name: example\n      url: http://example.com/healthz\nIndicates if a blackbox target for the cloud's auth endpoint should be created",
+              "properties": {
+                "enabled": {
+                  "default": true,
+                  "title": "enabled",
+                  "type": "boolean"
+                }
+              },
+              "required": [],
+              "title": "openstackAuthUrlTarget",
+              "type": "object"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "monitoring-system",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": true,
+                  "required": [],
+                  "title": "values"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "blackboxExporter",
+          "type": "object"
+        },
+        "enabled": {
+          "default": false,
+          "description": "Indicates if the cluster monitoring should be enabled",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "kubePrometheusStack": {
+          "additionalProperties": false,
+          "description": "Config for the kube-prometheus-stack helm chart\nhttps://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack",
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "kube-prometheus-stack",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://prometheus-community.github.io/helm-charts",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "85.0.2",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "monitoring-system",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "alertmanager": {
+                      "additionalProperties": false,
+                      "description": "Enable persistence by default for prometheus and alertmanager",
+                      "properties": {
+                        "alertmanagerSpec": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "retention": {
+                              "default": "168h",
+                              "description": "By default, retain 7 days of data",
+                              "title": "retention",
+                              "type": "string"
+                            },
+                            "storage": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "volumeClaimTemplate": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "spec": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "accessModes": {
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "required": []
+                                          },
+                                          "title": "accessModes",
+                                          "type": "array"
+                                        },
+                                        "resources": {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "requests": {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "storage": {
+                                                  "default": "10Gi",
+                                                  "title": "storage",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [],
+                                              "title": "requests",
+                                              "type": "object"
+                                            }
+                                          },
+                                          "required": [],
+                                          "title": "resources",
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [],
+                                      "title": "spec",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "required": [],
+                                  "title": "volumeClaimTemplate",
+                                  "type": "object"
+                                }
+                              },
+                              "required": [],
+                              "title": "storage",
+                              "type": "object"
+                            }
+                          },
+                          "required": [],
+                          "title": "alertmanagerSpec",
+                          "type": "object"
+                        }
+                      },
+                      "required": [],
+                      "title": "alertmanager",
+                      "type": "object"
+                    },
+                    "prometheus": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "prometheusSpec": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "retention": {
+                              "default": "90d",
+                              "description": "The amount of data that is retained will be 90 days or 95% of the size of the\npersistent volume, whichever is reached first",
+                              "title": "retention",
+                              "type": "string"
+                            },
+                            "storageSpec": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "volumeClaimTemplate": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "spec": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "accessModes": {
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "required": []
+                                          },
+                                          "title": "accessModes",
+                                          "type": "array"
+                                        },
+                                        "resources": {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "requests": {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "storage": {
+                                                  "default": "10Gi",
+                                                  "title": "storage",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [],
+                                              "title": "requests",
+                                              "type": "object"
+                                            }
+                                          },
+                                          "required": [],
+                                          "title": "resources",
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [],
+                                      "title": "spec",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "required": [],
+                                  "title": "volumeClaimTemplate",
+                                  "type": "object"
+                                }
+                              },
+                              "required": [],
+                              "title": "storageSpec",
+                              "type": "object"
+                            }
+                          },
+                          "required": [],
+                          "title": "prometheusSpec",
+                          "type": "object"
+                        }
+                      },
+                      "required": [],
+                      "title": "prometheus",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "values"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "kubePrometheusStack",
+          "type": "object"
+        },
+        "lokiStack": {
+          "additionalProperties": false,
+          "deprecated": true,
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "loki-stack",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://grafana.github.io/helm-charts",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "2.10.2",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "enabled": {
+              "default": true,
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "monitoring-system",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "loki": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "config": {
+                          "additionalProperties": false,
+                          "description": "Enable retention and configure a default retention period of 31 days",
+                          "properties": {
+                            "compactor": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "retention_enabled": {
+                                  "default": true,
+                                  "title": "retention_enabled",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [],
+                              "title": "compactor",
+                              "type": "object"
+                            },
+                            "limits_config": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "retention_period": {
+                                  "default": "72h",
+                                  "title": "retention_period",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [],
+                              "title": "limits_config",
+                              "type": "object"
+                            }
+                          },
+                          "required": [],
+                          "title": "config",
+                          "type": "object"
+                        },
+                        "persistence": {
+                          "additionalProperties": false,
+                          "description": "Enable persistence by default",
+                          "properties": {
+                            "enabled": {
+                              "default": true,
+                              "title": "enabled",
+                              "type": "boolean"
+                            },
+                            "size": {
+                              "default": "10Gi",
+                              "title": "size",
+                              "type": "string"
+                            }
+                          },
+                          "required": [],
+                          "title": "persistence",
+                          "type": "object"
+                        }
+                      },
+                      "required": [],
+                      "title": "loki",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "values"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "lokiStack"
+        }
+      },
+      "required": [],
+      "title": "monitoring",
+      "type": "object"
+    },
+    "nodeFeatureDiscovery": {
+      "additionalProperties": false,
+      "description": "Settings for node feature discovery\nhttps://github.com/kubernetes-sigs/node-feature-discovery/tree/master/deployment/helm/node-feature-discovery",
+      "properties": {
+        "chart": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "default": "node-feature-discovery",
+              "title": "name",
+              "type": "string"
+            },
+            "repo": {
+              "default": "https://kubernetes-sigs.github.io/node-feature-discovery/charts",
+              "title": "repo",
+              "type": "string"
+            },
+            "version": {
+              "default": "0.18.3",
+              "title": "version",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "chart",
+          "type": "object"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Indicates if node feature discovery should be enabled",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "release": {
+          "additionalProperties": false,
+          "properties": {
+            "namespace": {
+              "default": "node-feature-discovery",
+              "title": "namespace",
+              "type": "string"
+            },
+            "values": {
+              "additionalProperties": true,
+              "required": [],
+              "title": "values"
+            }
+          },
+          "required": [],
+          "title": "release",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "nodeFeatureDiscovery",
+      "type": "object"
+    },
+    "nodeProblemDetector": {
+      "additionalProperties": false,
+      "description": "Settings for the node problem detector",
+      "properties": {
+        "chart": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "default": "node-problem-detector",
+              "title": "name",
+              "type": "string"
+            },
+            "repo": {
+              "default": "https://charts.deliveryhero.io",
+              "title": "repo",
+              "type": "string"
+            },
+            "version": {
+              "default": "2.3.14",
+              "title": "version",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "chart",
+          "type": "object"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Indicates if the node problem detector should be enabled",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "release": {
+          "additionalProperties": false,
+          "properties": {
+            "namespace": {
+              "default": "node-problem-detector",
+              "title": "namespace",
+              "type": "string"
+            },
+            "values": {
+              "additionalProperties": true,
+              "required": [],
+              "title": "values"
+            }
+          },
+          "required": [],
+          "title": "release",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "nodeProblemDetector",
+      "type": "object"
+    },
+    "amdGPUOperator": {
+      "additionalProperties": false,
+      "description": "Settings for the AMD GPU operator",
+      "properties": {
+        "chart": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "default": "gpu-operator-charts",
+              "title": "name",
+              "type": "string"
+            },
+            "repo": {
+              "default": "https://rocm.github.io/gpu-operator",
+              "title": "repo",
+              "type": "string"
+            },
+            "version": {
+              "default": "v1.4.1",
+              "title": "version",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "chart",
+          "type": "object"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Indicates if the AMD GPU operator should be enabled\nNote that because it uses node feature discovery to run only on nodes\nwith an AMD GPU available, the overhead of enabling this on clusters\nthat do not need it now but may need it in the future is low",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "release": {
+          "additionalProperties": false,
+          "properties": {
+            "namespace": {
+              "default": "kube-amd-gpu",
+              "title": "namespace",
+              "type": "string"
+            },
+            "values": {
+              "additionalProperties": true,
+              "properties": {},
+              "required": [],
+              "title": "values"
+            }
+          },
+          "required": [],
+          "title": "release",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "amdGPUOperator",
+      "type": "object"
+    },
+    "nvidiaGPUOperator": {
+      "additionalProperties": false,
+      "description": "Settings for the NVIDIA GPU operator",
+      "properties": {
+        "chart": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "default": "gpu-operator",
+              "title": "name",
+              "type": "string"
+            },
+            "repo": {
+              "default": "https://helm.ngc.nvidia.com/nvidia",
+              "title": "repo",
+              "type": "string"
+            },
+            "version": {
+              "default": "v26.3.1",
+              "title": "version",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "chart",
+          "type": "object"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Indicates if the NVIDIA GPU operator should be enabled\nNote that because it uses node feature discovery to run only on nodes\nwith an NVIDIA GPU available, the overhead of enabling this on clusters\nthat do not need it now but may need it in the future is low",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "release": {
+          "additionalProperties": false,
+          "properties": {
+            "namespace": {
+              "default": "gpu-operator",
+              "title": "namespace",
+              "type": "string"
+            },
+            "values": {
+              "additionalProperties": true,
+              "properties": {
+                "dcgmExporter": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "serviceMonitor": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "enabled": {
+                          "default": true,
+                          "title": "enabled",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [],
+                      "title": "serviceMonitor",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "dcgmExporter",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "values"
+            }
+          },
+          "required": [],
+          "title": "release",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "nvidiaGPUOperator",
+      "type": "object"
+    },
+    "openstack": {
+      "additionalProperties": false,
+      "description": "Settings for the OpenStack integrations",
+      "properties": {
+        "ccm": {
+          "additionalProperties": false,
+          "description": "Settings for the Cloud Controller Manager (CCM)",
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "openstack-cloud-controller-manager",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://kubernetes.github.io/cloud-provider-openstack",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "2.36.0",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "enabled": {
+              "default": true,
+              "description": "Indicates if the OpenStack CCM should be enabled\nBy default, the CCM is enabled if the OpenStack integrations are enabled\nSee https://github.com/kubernetes/cloud-provider-openstack/blob/master/charts/openstack-cloud-controller-manager/values.yaml",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "values": {
+              "additionalProperties": true,
+              "required": [],
+              "title": "values"
+            }
+          },
+          "required": [],
+          "title": "ccm",
+          "type": "object"
+        },
+        "cloudConfig": {
+          "additionalProperties": false,
+          "description": "cloud-config options for the OpenStack integrations\nThe [Global] section is configured to use the target cloud\nSee https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#config-openstack-cloud-controller-manager\nand https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/cinder-csi-plugin/using-cinder-csi-plugin.md#block-storage",
+          "properties": {
+            "BlockStorage": {
+              "additionalProperties": false,
+              "description": "By default, ignore volume AZs for Cinder as most clouds have a single globally-attachable Cinder AZ",
+              "properties": {
+                "ignore-volume-az": {
+                  "default": true,
+                  "title": "ignore-volume-az",
+                  "type": "boolean"
+                }
+              },
+              "required": [],
+              "title": "BlockStorage",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "cloudConfig",
+          "type": "object"
+        },
+        "csiCinder": {
+          "additionalProperties": false,
+          "description": "Settings for the Cinder CSI plugin",
+          "properties": {
+            "additionalStorageClasses": {
+              "description": "Additional storage classes to create for the Cinder CSI\nFor each item, the properties from the default storage class are supported (except enabled and isClusterDefault)",
+              "items": {
+                "required": []
+              },
+              "title": "additionalStorageClasses",
+              "type": "array"
+            },
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "openstack-cinder-csi",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://kubernetes.github.io/cloud-provider-openstack",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "2.35.0",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "defaultStorageClass": {
+              "additionalProperties": false,
+              "description": "Definition of the default storage class for Cinder CSI",
+              "properties": {
+                "allowVolumeExpansion": {
+                  "default": true,
+                  "description": "Indicates if volume expansion is allowed",
+                  "title": "allowVolumeExpansion",
+                  "type": "boolean"
+                },
+                "allowedTopologies": {
+                  "additionalProperties": true,
+                  "default": "",
+                  "description": "The allowed topologies for the storage class",
+                  "required": [],
+                  "title": "allowedTopologies",
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "availabilityZone": {
+                  "default": "nova",
+                  "description": "The Cinder availability zone to use for volumes provisioned by the storage class",
+                  "title": "availabilityZone",
+                  "type": "string"
+                },
+                "enabled": {
+                  "default": true,
+                  "description": "Indicates if the storage class should be enabled",
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "fstype": {
+                  "default": "",
+                  "description": "Filesystem type to use for volumes provisioned with the storage class\nIf not given, the default filesystem type will be used",
+                  "required": [],
+                  "title": "fstype",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "isClusterDefault": {
+                  "default": true,
+                  "description": "Indicates if the Cinder default storage class is the cluster default storage class",
+                  "title": "isClusterDefault",
+                  "type": "boolean"
+                },
+                "name": {
+                  "default": "csi-cinder",
+                  "description": "The name of the storage class",
+                  "title": "name",
+                  "type": "string"
+                },
+                "reclaimPolicy": {
+                  "default": "Delete",
+                  "description": "The reclaim policy for the storage class",
+                  "title": "reclaimPolicy",
+                  "type": "string"
+                },
+                "volumeBindingMode": {
+                  "default": "WaitForFirstConsumer",
+                  "description": "Controls when volume binding and dynamic provisioning should occur",
+                  "title": "volumeBindingMode",
+                  "type": "string"
+                },
+                "volumeType": {
+                  "default": "",
+                  "description": "The Cinder volume type to use for volumes provisioned by the storage class\nIf not given, the default volume type will be used",
+                  "required": [],
+                  "title": "volumeType",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [],
+              "title": "defaultStorageClass",
+              "type": "object"
+            },
+            "enabled": {
+              "default": true,
+              "description": "Indicates if the Cinder CSI should be enabled\nBy default, it is enabled if the OpenStack integrations are enabled\nSee https://github.com/kubernetes/cloud-provider-openstack/blob/master/charts/cinder-csi-plugin/values.yaml",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "values": {
+              "additionalProperties": true,
+              "properties": {
+                "csi": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "plugin": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "controllerPlugin": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "nodeSelector": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "node-role.kubernetes.io/control-plane": {
+                                  "default": "",
+                                  "title": "node-role.kubernetes.io/control-plane",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [],
+                              "title": "nodeSelector",
+                              "type": "object"
+                            },
+                            "tolerations": {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "effect": {
+                                        "default": "NoSchedule",
+                                        "title": "effect",
+                                        "type": "string"
+                                      },
+                                      "key": {
+                                        "default": "node-role.kubernetes.io/control-plane",
+                                        "title": "key",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "effect"
+                                    ],
+                                    "type": "object"
+                                  }
+                                ],
+                                "required": []
+                              },
+                              "title": "tolerations",
+                              "type": "array"
+                            }
+                          },
+                          "required": [],
+                          "title": "controllerPlugin",
+                          "type": "object"
+                        }
+                      },
+                      "required": [],
+                      "title": "plugin",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "csi",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "values"
+            }
+          },
+          "required": [],
+          "title": "csiCinder",
+          "type": "object"
+        },
+        "csiManila": {
+          "additionalProperties": false,
+          "description": "Settings for the Manila CSI plugin",
+          "properties": {
+            "additionalStorageClasses": {
+              "description": "Additional storage classes to create for the Manila CSI\nFor each item, the properties from the default storage class are supported (except for \"enabled\")",
+              "items": {
+                "required": []
+              },
+              "title": "additionalStorageClasses",
+              "type": "array"
+            },
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "openstack-manila-csi",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://kubernetes.github.io/cloud-provider-openstack",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "2.30.0",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "defaultStorageClass": {
+              "additionalProperties": false,
+              "description": "Definition of the default storage class for the Manila CSI",
+              "properties": {
+                "allowVolumeExpansion": {
+                  "default": true,
+                  "description": "Indicates if volume expansion is allowed",
+                  "title": "allowVolumeExpansion",
+                  "type": "boolean"
+                },
+                "allowedTopologies": {
+                  "default": "",
+                  "description": "The allowed topologies for the storage class",
+                  "required": [],
+                  "title": "allowedTopologies",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "enabled": {
+                  "default": true,
+                  "description": "Indicates if the storage class should be enabled",
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "isClusterDefault": {
+                  "default": false,
+                  "description": "Indicates if the Manila default storage class is the cluster default storage class",
+                  "title": "isClusterDefault",
+                  "type": "boolean"
+                },
+                "name": {
+                  "default": "csi-manila",
+                  "description": "The name of the storage class",
+                  "title": "name",
+                  "type": "string"
+                },
+                "parameters": {
+                  "additionalProperties": true,
+                  "description": "The parameters for the storage class\nSee https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/manila-csi-plugin/using-manila-csi-plugin.md#controller-service-volume-parameters",
+                  "properties": {
+                    "type": {
+                      "default": "",
+                      "description": "The Manila share type to use\nIf not given and the Ceph CSI plugin is installed, cephfs is used",
+                      "required": [],
+                      "title": "type",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [],
+                  "title": "parameters"
+                },
+                "provisioner": {
+                  "default": "",
+                  "description": "The provisioner for the storage class\nIf not given and the Ceph CSI plugin is installed, cephfs.manila.csi.openstack.org is used",
+                  "required": [],
+                  "title": "provisioner",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "reclaimPolicy": {
+                  "default": "Delete",
+                  "description": "The reclaim policy for the storage class",
+                  "title": "reclaimPolicy",
+                  "type": "string"
+                },
+                "volumeBindingMode": {
+                  "default": "WaitForFirstConsumer",
+                  "description": "Controls when volume binding and dynamic provisioning should occur",
+                  "title": "volumeBindingMode",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "defaultStorageClass",
+              "type": "object"
+            },
+            "enabled": {
+              "default": false,
+              "description": "Indicates if the Manila CSI should be enabled\nBy default, it is disabled as Manila is not commonly available\nSee https://github.com/kubernetes/cloud-provider-openstack/blob/master/charts/manila-csi-plugin/values.yaml",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "values": {
+              "additionalProperties": true,
+              "required": [],
+              "title": "values"
+            }
+          },
+          "required": [],
+          "title": "csiManila",
+          "type": "object"
+        },
+        "enabled": {
+          "default": false,
+          "description": "Indicates if the OpenStack integrations should be enabled",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "k8sKeystoneAuth": {
+          "additionalProperties": false,
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "k8s-keystone-auth",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://catalyst-cloud.github.io/capi-plugin-helm-charts",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "1.5.1",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "enabled": {
+              "default": false,
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "targetNamespace": {
+              "default": "kube-system",
+              "title": "targetNamespace",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "k8sKeystoneAuth",
+          "type": "object"
+        },
+        "targetNamespace": {
+          "default": "openstack-system",
+          "description": "The target namespace for the OpenStack integrations",
+          "title": "targetNamespace",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "openstack",
+      "type": "object"
+    },
+    "reloader": {
+      "additionalProperties": false,
+      "description": "Setting for Reloader used to restart workloads on Secret/ConfigMap changes",
+      "properties": {
+        "chart": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "default": "reloader",
+              "title": "name",
+              "type": "string"
+            },
+            "repo": {
+              "default": "https://stakater.github.io/stakater-charts",
+              "title": "repo",
+              "type": "string"
+            },
+            "version": {
+              "default": "2.2.11",
+              "title": "version",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "chart",
+          "type": "object"
+        },
+        "enabled": {
+          "default": false,
+          "description": "Indicates if Reloader should be enabled",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "release": {
+          "additionalProperties": false,
+          "properties": {
+            "namespace": {
+              "default": "openstack-system",
+              "description": "Deploy to the same namespace as OpenStack services",
+              "title": "namespace",
+              "type": "string"
+            },
+            "values": {
+              "additionalProperties": true,
+              "properties": {
+                "reloader": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "watchGlobally": {
+                      "default": false,
+                      "description": "Restrict scope to namespace",
+                      "title": "watchGlobally",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [],
+                  "title": "reloader",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "values"
+            }
+          },
+          "required": [],
+          "title": "release",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "reloader",
+      "type": "object"
+    }
+  },
+  "required": [
+    "enabled",
+    "cni",
+    "csi",
+    "openstack",
+    "reloader",
+    "etcdDefrag",
+    "metricsServer",
+    "ingress",
+    "monitoring",
+    "nodeFeatureDiscovery",
+    "nvidiaGPUOperator",
+    "amdGPUOperator",
+    "intelDevicePlugin",
+    "certManager",
+    "mellanoxNetworkOperator",
+    "nodeProblemDetector"
+  ],
+  "type": "object"
+}

--- a/charts/cluster-addons/values.yaml
+++ b/charts/cluster-addons/values.yaml
@@ -1,323 +1,968 @@
 ---
+# yaml-language-server: $schema=values.schema.json
+
+# @schema
+# type: boolean
+# @schema
+# Included for schema validation purposes.
+# Has no effect unless this chart is used
+# as a conditional dependency of the
+# openstack-cluster chart.
+enabled: true
 
 # The name of the Cluster API cluster
 # if not given, the release name is used
+# @schema
+# type: [string, null]
+# @schema
 clusterName:
 
+# @schema
+# type: object
+# @schema
 # Settings for the CNI addon
 cni:
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates if a CNI should be deployed
   enabled: true
   # The CNI to deploy - supported values are calico or cilium
+  # @schema
+  # enum: [calico, cilium]
+  # @schema
   type: calico
+  # @schema
+  # type: object
+  # @schema
   # Settings for the calico CNI
   # See https://projectcalico.docs.tigera.io/getting-started/kubernetes/helm
   calico:
+    # @schema
+    # type: object
+    # @schema
     chart:
+      # @schema
+      # type: string
+      # @schema
       repo: https://projectcalico.docs.tigera.io/charts
+      # @schema
+      # type: string
+      # @schema
       name: tigera-operator
+      # @schema
+      # type: string
+      # @schema
       version: v3.31.5
+    # @schema
+    # type: object
+    # @schema
     release:
+      # @schema
+      # type: string
+      # @schema
       namespace: tigera-operator
+      # @schema
+      # additionalProperties: true
+      # @schema
       values:
+        # @schema
+        # type: object
+        # @schema
         nodeSelector:
+          # @schema
+          # type: string
+          # @schema
           node-role.kubernetes.io/control-plane: ""
+    # @schema
+    # type: object
+    # @schema
     # Nova metadata service
     # See https://docs.openstack.org/nova/latest/user/metadata.html#the-metadata-service
     globalNetworkPolicy:
+      # @schema
+      # type: string
+      # @schema
       denyNamespaceSelector: kubernetes.io/metadata.name != 'openstack-system'
+      # @schema
+      # type: integer
+      # @schema
       allowPriority: 20
+      # @schema
+      # type: integer
+      # @schema
       denyPriority: 10
+      # @schema
+      # type: array
+      # @schema
       allowEgressCidrs:
         - "0.0.0.0/0"
+      # @schema
+      # type: array
+      # @schema
       denyEgressCidrs:
         - "169.254.169.254/32"
+      # @schema
+      # type: array
+      # @schema
       allowv6EgressCidrs:
         - "::/0"
+      # @schema
+      # type: array
+      # @schema
       denyv6EgressCidrs:
         - "fe80::a9fe:a9fe/128"
+  # @schema
+  # type: object
+  # @schema
   # Settings for the Cilium CNI
   # See https://docs.cilium.io/en/stable/gettingstarted/k8s-install-helm/ for details
   cilium:
+    # @schema
+    # type: object
+    # @schema
     chart:
+      # @schema
+      # type: string
+      # @schema
       repo: https://helm.cilium.io/
+      # @schema
+      # type: string
+      # @schema
       name: cilium
+      # @schema
+      # type: string
+      # @schema
       version: 1.19.3
+    # @schema
+    # type: object
+    # @schema
     release:
+      # @schema
+      # type: string
+      # @schema
       namespace: kube-system
+      # @schema
+      # additionalProperties: true
+      # @schema
       values: {}
 
+# @schema
+# type: object
+# @schema
 # Settings for CSI addons
 csi:
+  # @schema
+  # type: object
+  # @schema
   # Settings for the CephFS CSI
   cephfs:
+    # @schema
+    # type: boolean
+    # @schema
     enabled: false
+    # @schema
+    # type: object
+    # @schema
     chart:
+      # @schema
+      # type: string
+      # @schema
       repo: https://ceph.github.io/csi-charts
+      # @schema
+      # type: string
+      # @schema
       name: ceph-csi-cephfs
+      # @schema
+      # type: string
+      # @schema
       version: 3.11.0
+    # @schema
+    # type: object
+    # @schema
     release:
+      # @schema
+      # type: string
+      # @schema
       namespace: csi-ceph-system
+      # @schema
+      # additionalProperties: true
+      # @schema
       values: {}
 
+# @schema
+# type: object
+# @schema
 # Settings for the OpenStack integrations
 openstack:
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates if the OpenStack integrations should be enabled
   enabled: false
+  # @schema
+  # type: string
+  # @schema
   # The target namespace for the OpenStack integrations
   targetNamespace: openstack-system
+  # @schema
+  # type: object
+  # @schema
   # cloud-config options for the OpenStack integrations
   # The [Global] section is configured to use the target cloud
   # See https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#config-openstack-cloud-controller-manager
   # and https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/cinder-csi-plugin/using-cinder-csi-plugin.md#block-storage
   cloudConfig:
+    # @schema
+    # type: object
+    # @schema
     # By default, ignore volume AZs for Cinder as most clouds have a single globally-attachable Cinder AZ
     BlockStorage:
+      # @schema
+      # type: boolean
+      # @schema
       ignore-volume-az: true
+  # @schema
+  # type: object
+  # @schema
   # Settings for the Cloud Controller Manager (CCM)
   ccm:
+    # @schema
+    # type: boolean
+    # @schema
     # Indicates if the OpenStack CCM should be enabled
     # By default, the CCM is enabled if the OpenStack integrations are enabled
     # See https://github.com/kubernetes/cloud-provider-openstack/blob/master/charts/openstack-cloud-controller-manager/values.yaml
     enabled: true
+    # @schema
+    # type: object
+    # @schema
     chart:
+      # @schema
+      # type: string
+      # @schema
       repo: https://kubernetes.github.io/cloud-provider-openstack
+      # @schema
+      # type: string
+      # @schema
       name: openstack-cloud-controller-manager
+      # @schema
+      # type: string
+      # @schema
       version: 2.36.0
+    # @schema
+    # additionalProperties: true
+    # @schema
     values: {}
+  # @schema
+  # type: object
+  # @schema
   # Settings for the Cinder CSI plugin
   csiCinder:
+    # @schema
+    # type: boolean
+    # @schema
     # Indicates if the Cinder CSI should be enabled
     # By default, it is enabled if the OpenStack integrations are enabled
     # See https://github.com/kubernetes/cloud-provider-openstack/blob/master/charts/cinder-csi-plugin/values.yaml
     enabled: true
+    # @schema
+    # type: object
+    # @schema
     chart:
+      # @schema
+      # type: string
+      # @schema
       repo: https://kubernetes.github.io/cloud-provider-openstack
+      # @schema
+      # type: string
+      # @schema
       name: openstack-cinder-csi
+      # @schema
+      # type: string
+      # @schema
       version: 2.35.0
+    # @schema
+    # additionalProperties: true
+    # @schema
     values:
+      # @schema
+      # type: object
+      # @schema
       csi:
+        # @schema
+        # type: object
+        # @schema
         plugin:
+          # @schema
+          # type: object
+          # @schema
           controllerPlugin:
+            # @schema
+            # type: object
+            # @schema
             nodeSelector:
+              # @schema
+              # type: string
+              # @schema
               node-role.kubernetes.io/control-plane: ""
+            # @schema
+            # type: array
+            # @schema
             tolerations:
               - key: node-role.kubernetes.io/control-plane
                 effect: NoSchedule
+    # @schema
+    # type: object
+    # @schema
     # Definition of the default storage class for Cinder CSI
     defaultStorageClass:
+      # @schema
+      # type: boolean
+      # @schema
       # Indicates if the storage class should be enabled
       enabled: true
+      # @schema
+      # type: string
+      # @schema
       # The name of the storage class
       name: csi-cinder
+      # @schema
+      # type: boolean
+      # @schema
       # Indicates if the Cinder default storage class is the cluster default storage class
       isClusterDefault: true
+      # @schema
+      # type: string
+      # @schema
       # The reclaim policy for the storage class
       reclaimPolicy: Delete
+      # @schema
+      # type: boolean
+      # @schema
       # Indicates if volume expansion is allowed
       allowVolumeExpansion: true
+      # @schema
+      # type: string
+      # @schema
       # Controls when volume binding and dynamic provisioning should occur
       volumeBindingMode: WaitForFirstConsumer
       # The allowed topologies for the storage class
+      # @schema
+      # type: [object, null]
+      # additionalProperties: true
+      # @schema
       allowedTopologies:
       # Filesystem type to use for volumes provisioned with the storage class
       # If not given, the default filesystem type will be used
+      # @schema
+      # type: [string, null]
+      # @schema
       fstype:
+      # @schema
+      # type: string
+      # @schema
       # The Cinder availability zone to use for volumes provisioned by the storage class
       availabilityZone: nova
       # The Cinder volume type to use for volumes provisioned by the storage class
       # If not given, the default volume type will be used
+      # @schema
+      # type: [string, null]
+      # @schema
       volumeType:
+    # @schema
+    # type: array
+    # @schema
     # Additional storage classes to create for the Cinder CSI
     # For each item, the properties from the default storage class are supported (except enabled and isClusterDefault)
     additionalStorageClasses: []
+  # @schema
+  # type: object
+  # @schema
   # Settings for the Manila CSI plugin
   csiManila:
+    # @schema
+    # type: boolean
+    # @schema
     # Indicates if the Manila CSI should be enabled
     # By default, it is disabled as Manila is not commonly available
     # See https://github.com/kubernetes/cloud-provider-openstack/blob/master/charts/manila-csi-plugin/values.yaml
     enabled: false
+    # @schema
+    # type: object
+    # @schema
     chart:
+      # @schema
+      # type: string
+      # @schema
       repo: https://kubernetes.github.io/cloud-provider-openstack
+      # @schema
+      # type: string
+      # @schema
       name: openstack-manila-csi
+      # @schema
+      # type: string
+      # @schema
       version: 2.30.0
+    # @schema
+    # additionalProperties: true
+    # @schema
     values: {}
+    # @schema
+    # type: object
+    # @schema
     # Definition of the default storage class for the Manila CSI
     defaultStorageClass:
+      # @schema
+      # type: boolean
+      # @schema
       # Indicates if the storage class should be enabled
       enabled: true
+      # @schema
+      # type: string
+      # @schema
       # The name of the storage class
       name: csi-manila
+      # @schema
+      # type: boolean
+      # @schema
       # Indicates if the Manila default storage class is the cluster default storage class
       isClusterDefault: false
       # The provisioner for the storage class
       # If not given and the Ceph CSI plugin is installed, cephfs.manila.csi.openstack.org is used
+      # @schema
+      # type: [string, null]
+      # @schema
       provisioner:
+      # @schema
+      # type: string
+      # @schema
       # The reclaim policy for the storage class
       reclaimPolicy: Delete
+      # @schema
+      # type: boolean
+      # @schema
       # Indicates if volume expansion is allowed
       allowVolumeExpansion: true
+      # @schema
+      # type: string
+      # @schema
       # Controls when volume binding and dynamic provisioning should occur
       volumeBindingMode: WaitForFirstConsumer
       # The allowed topologies for the storage class
+      # @schema
+      # type: [string, null]
+      # @schema
       allowedTopologies:
       # The parameters for the storage class
       # See https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/manila-csi-plugin/using-manila-csi-plugin.md#controller-service-volume-parameters
+      # @schema
+      # additionalProperties: true
+      # @schema
       parameters:
         # The Manila share type to use
         # If not given and the Ceph CSI plugin is installed, cephfs is used
+        # @schema
+        # type: [string, null]
+        # @schema
         type:
+    # @schema
+    # type: array
+    # @schema
     # Additional storage classes to create for the Manila CSI
     # For each item, the properties from the default storage class are supported (except for "enabled")
     additionalStorageClasses: []
+  # @schema
+  # type: object
+  # @schema
   k8sKeystoneAuth:
+    # @schema
+    # type: boolean
+    # @schema
     enabled: false
+    # @schema
+    # type: string
+    # @schema
     targetNamespace: kube-system
+    # @schema
+    # type: object
+    # @schema
     chart:
+      # @schema
+      # type: string
+      # @schema
       repo: https://catalyst-cloud.github.io/capi-plugin-helm-charts
+      # @schema
+      # type: string
+      # @schema
       name: k8s-keystone-auth
+      # @schema
+      # type: string
+      # @schema
       version: 1.5.1
 
+# @schema
+# type: object
+# @schema
 # Setting for Reloader used to restart workloads on Secret/ConfigMap changes
 reloader:
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates if Reloader should be enabled
   enabled: false
+  # @schema
+  # type: object
+  # @schema
   chart:
+    # @schema
+    # type: string
+    # @schema
     repo: https://stakater.github.io/stakater-charts
+    # @schema
+    # type: string
+    # @schema
     name: reloader
+    # @schema
+    # type: string
+    # @schema
     version: 2.2.11
+  # @schema
+  # type: object
+  # @schema
   release:
+    # @schema
+    # type: string
+    # @schema
     # Deploy to the same namespace as OpenStack services
     namespace: openstack-system
+    # @schema
+    # additionalProperties: true
+    # @schema
     values:
+      # @schema
+      # type: object
+      # @schema
       reloader:
+        # @schema
+        # type: boolean
+        # @schema
         # Restrict scope to namespace
         watchGlobally: false
 
+# @schema
+# type: object
+# @schema
 # Settings for etcd defragmentation jobs
 etcdDefrag:
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates if the etcd defragmentation job should be enabled
   enabled: true
+  # @schema
+  # type: object
+  # @schema
   chart:
+    # @schema
+    # type: string
+    # @schema
     repo: https://azimuth-cloud.github.io/capi-helm-charts
+    # @schema
+    # type: string
+    # @schema
     name: etcd-defrag
+    # @schema
+    # type: [string, null]
+    # @schema
     version:  # Defaults to the same version as this chart
+  # @schema
+  # type: object
+  # @schema
   release:
+    # @schema
+    # type: string
+    # @schema
     # This should be namespace in which the etcd pods are deployed
     namespace: kube-system
+    # @schema
+    # additionalProperties: true
+    # @schema
     values: {}
 
+# @schema
+# type: object
+# @schema
 # Settings for the metrics server
 # https://github.com/kubernetes-sigs/metrics-server#helm-chart
 metricsServer:
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates if the metrics server should be deployed
   enabled: true
+  # @schema
+  # type: object
+  # @schema
   chart:
+    # @schema
+    # type: string
+    # @schema
     repo: https://kubernetes-sigs.github.io/metrics-server
+    # @schema
+    # type: string
+    # @schema
     name: metrics-server
+    # @schema
+    # type: string
+    # @schema
     version: 3.13.0
+  # @schema
+  # type: object
+  # @schema
   release:
+    # @schema
+    # type: string
+    # @schema
     namespace: kube-system
+    # @schema
+    # additionalProperties: true
+    # @schema
     values: {}
 
+# @schema
+# type: object
+# @schema
 # Settings for ingress controllers
 ingress:
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates if ingress controllers should be enabled
   enabled: false
+  # @schema
+  # type: object
+  # @schema
   # Settings for the Nginx ingress controller
   # https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx#configuration
   nginx:
+    # @schema
+    # type: boolean
+    # @schema
     # Indicates if the Nginx ingress controller should be enabled
     enabled: false
+    # @schema
+    # type: object
+    # @schema
     chart:
+      # @schema
+      # type: string
+      # @schema
       repo: https://kubernetes.github.io/ingress-nginx
+      # @schema
+      # type: string
+      # @schema
       name: ingress-nginx
+      # @schema
+      # type: string
+      # @schema
       version: 4.15.1
+    # @schema
+    # type: object
+    # @schema
     release:
+      # @schema
+      # type: string
+      # @schema
       namespace: ingress-nginx
+      # @schema
+      # additionalProperties: true
+      # @schema
       values: {}
+  # @schema
+  # type: object
+  # @schema
   # Settings for the Traefik ingress controller
   # https://github.com/traefik/traefik-helm-chart/blob/master/EXAMPLES.md
   traefik:
+    # @schema
+    # type: boolean
+    # @schema
     # Indicates if the Traefik ingress controller should be enabled
     # The Traefik ingress controller is enabled by default if ingress controllers are enabled
     enabled: true
+    # @schema
+    # type: object
+    # @schema
     chart:
+      # @schema
+      # type: string
+      # @schema
       repo: https://traefik.github.io/charts
+      # @schema
+      # type: string
+      # @schema
       name: traefik
+      # @schema
+      # type: string
+      # @schema
       version: 40.1.0
+    # @schema
+    # type: object
+    # @schema
     release:
+      # @schema
+      # type: string
+      # @schema
       namespace: traefik
+      # @schema
+      # type: object
+      # @schema
       values: {}
 
+# @schema
+# type: object
+# @schema
 # Settings for cluster monitoring
 monitoring:
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates if the cluster monitoring should be enabled
   enabled: false
+  # @schema
+  # type: object
+  # @schema
   # Config for the kube-prometheus-stack helm chart
   # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack
   kubePrometheusStack:
+    # @schema
+    # type: object
+    # @schema
     chart:
+      # @schema
+      # type: string
+      # @schema
       repo: https://prometheus-community.github.io/helm-charts
+      # @schema
+      # type: string
+      # @schema
       name: kube-prometheus-stack
+      # @schema
+      # type: string
+      # @schema
       version: 85.0.2
+    # @schema
+    # type: object
+    # @schema
     release:
+      # @schema
+      # type: string
+      # @schema
       namespace: monitoring-system
+      # @schema
+      # additionalProperties: true
+      # @schema
       values:
+        # @schema
+        # type: object
+        # @schema
         # Enable persistence by default for prometheus and alertmanager
         alertmanager:
+          # @schema
+          # type: object
+          # @schema
           alertmanagerSpec:
+            # @schema
+            # type: string
+            # @schema
             # By default, retain 7 days of data
             retention: 168h
+            # @schema
+            # type: object
+            # @schema
             storage:
+              # @schema
+              # type: object
+              # @schema
               volumeClaimTemplate:
+                # @schema
+                # type: object
+                # @schema
                 spec:
+                  # @schema
+                  # type: array
+                  # @schema
                   accessModes: ["ReadWriteOnce"]
+                  # @schema
+                  # type: object
+                  # @schema
                   resources:
+                    # @schema
+                    # type: object
+                    # @schema
                     requests:
+                      # @schema
+                      # type: string
+                      # @schema
                       storage: 10Gi
+        # @schema
+        # type: object
+        # @schema
         prometheus:
+          # @schema
+          # type: object
+          # @schema
           prometheusSpec:
+            # @schema
+            # type: string
+            # @schema
             # The amount of data that is retained will be 90 days or 95% of the size of the
             # persistent volume, whichever is reached first
             retention: 90d
+            # @schema
+            # type: object
+            # @schema
             storageSpec:
+              # @schema
+              # type: object
+              # @schema
               volumeClaimTemplate:
+                # @schema
+                # type: object
+                # @schema
                 spec:
+                  # @schema
+                  # type: array
+                  # @schema
                   accessModes: ["ReadWriteOnce"]
+                  # @schema
+                  # type: object
+                  # @schema
                   resources:
+                    # @schema
+                    # type: object
+                    # @schema
                     requests:
+                      # @schema
+                      # type: string
+                      # @schema
                       storage: 10Gi
+
+  # @schema
+  # deprecated: true
+  # @schema
   lokiStack:
+    # @schema
+    # type: boolean
+    # @schema
     enabled: true
+    # @schema
+    # type: object
+    # @schema
     chart:
+      # @schema
+      # type: string
+      # @schema
       repo: https://grafana.github.io/helm-charts
+      # @schema
+      # type: string
+      # @schema
       name: loki-stack
+      # @schema
+      # type: string
+      # @schema
       version: 2.10.2
+    # @schema
+    # type: object
+    # @schema
     release:
+      # @schema
+      # type: string
+      # @schema
       namespace: monitoring-system
+      # @schema
+      # additionalProperties: true
+      # @schema
       values:
+        # @schema
+        # type: object
+        # @schema
         loki:
+          # @schema
+          # type: object
+          # @schema
           # Enable retention and configure a default retention period of 31 days
           config:
+            # @schema
+            # type: object
+            # @schema
             compactor:
+              # @schema
+              # type: boolean
+              # @schema
               retention_enabled: true
+            # @schema
+            # type: object
+            # @schema
             limits_config:
+              # @schema
+              # type: string
+              # @schema
               retention_period: 72h
+          # @schema
+          # type: object
+          # @schema
           # Enable persistence by default
           persistence:
+            # @schema
+            # type: boolean
+            # @schema
             enabled: true
+            # @schema
+            # type: string
+            # @schema
             size: 10Gi
+  # @schema
+  # type: object
+  # @schema
   # Configuration for the blackbox exporter
   blackboxExporter:
+    # @schema
+    # type: boolean
+    # @schema
     enabled: true
+    # @schema
+    # type: object
+    # @schema
     chart:
+      # @schema
+      # type: string
+      # @schema
       repo: https://prometheus-community.github.io/helm-charts
+      # @schema
+      # type: string
+      # @schema
       name: prometheus-blackbox-exporter
+      # @schema
+      # type: string
+      # @schema
       version: 11.9.1
+    # @schema
+    # type: object
+    # @schema
     release:
+      # @schema
+      # type: string
+      # @schema
       namespace: monitoring-system
+      # @schema
+      # additionalProperties: true
+      # @schema
       values: {}
+    # @schema
+    # type: object
+    # @schema
         # Example of adding additional scrape targets
         # serviceMonitor:
         #   targets:
@@ -325,132 +970,476 @@ monitoring:
         #       url: http://example.com/healthz
     # Indicates if a blackbox target for the cloud's auth endpoint should be created
     openstackAuthUrlTarget:
+      # @schema
+      # type: boolean
+      # @schema
       enabled: true
 
+# @schema
+# type: object
+# @schema
 # Settings for node feature discovery
 # https://github.com/kubernetes-sigs/node-feature-discovery/tree/master/deployment/helm/node-feature-discovery
 nodeFeatureDiscovery:
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates if node feature discovery should be enabled
   enabled: true
+  # @schema
+  # type: object
+  # @schema
   chart:
+    # @schema
+    # type: string
+    # @schema
     repo: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+    # @schema
+    # type: string
+    # @schema
     name: node-feature-discovery
+    # @schema
+    # type: string
+    # @schema
     version: 0.18.3
+  # @schema
+  # type: object
+  # @schema
   release:
+    # @schema
+    # type: string
+    # @schema
     namespace: node-feature-discovery
+    # @schema
+    # additionalProperties: true
+    # @schema
     values: {}
 
+# @schema
+# type: object
+# @schema
 # Settings for the NVIDIA GPU operator
 nvidiaGPUOperator:
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates if the NVIDIA GPU operator should be enabled
   # Note that because it uses node feature discovery to run only on nodes
   # with an NVIDIA GPU available, the overhead of enabling this on clusters
   # that do not need it now but may need it in the future is low
   enabled: true
+  # @schema
+  # type: object
+  # @schema
   chart:
+    # @schema
+    # type: string
+    # @schema
     repo: https://helm.ngc.nvidia.com/nvidia
+    # @schema
+    # type: string
+    # @schema
     name: gpu-operator
+    # @schema
+    # type: string
+    # @schema
     version: v26.3.1
+  # @schema
+  # type: object
+  # @schema
   release:
+    # @schema
+    # type: string
+    # @schema
     namespace: gpu-operator
+    # @schema
+    # additionalProperties: true
+    # @schema
     values:
+      # @schema
+      # type: object
+      # @schema
       dcgmExporter:
+        # @schema
+        # type: object
+        # @schema
         serviceMonitor:
+          # @schema
+          # type: boolean
+          # @schema
           enabled: true
 
+# @schema
+# type: object
+# @schema
 amdGPUOperator:
+  # @schema
+  # type: boolean
+  # @schema
   enabled: false
+  # @schema
+  # type: object
+  # @schema
   chart:
+    # @schema
+    # type: string
+    # @schema
     repo: https://rocm.github.io/gpu-operator
+    # @schema
+    # type: string
+    # @schema
     name: gpu-operator-charts
+    # @schema
+    # type: string
+    # @schema
     version: v1.5.0
+  # @schema
+  # type: object
+  # @schema
   release:
+    # @schema
+    # type: string
+    # @schema
     namespace: kube-amd-gpu
+    # @schema
+    # type: object
+    # @schema
     values: {}
 
+# @schema
+# type: object
+# @schema
 intelDevicePlugin:
+  # @schema
+  # type: boolean
+  # @schema
   enabled: false
+  # @schema
+  # type: object
+  # @schema
   operator:
+    # @schema
+    # type: object
+    # @schema
     chart:
+      # @schema
+      # type: string
+      # @schema
       repo: https://intel.github.io/helm-charts
+      # @schema
+      # type: string
+      # @schema
       name: intel-device-plugins-operator
+      # @schema
+      # type: string
+      # @schema
       version: 0.32.0
+    # @schema
+    # type: object
+    # @schema
     release:
+      # @schema
+      # type: string
+      # @schema
       namespace: intel
+      # @schema
+      # additionalProperties: true
+      # @schema
       values:
+        # @schema
+        # type: object
+        # @schema
         manager:
+          # @schema
+          # type: object
+          # @schema
           devices:
+            # @schema
+            # type: boolean
+            # @schema
             gpu: true
+        # @schema
+        # type: object
+        # @schema
         resources:
+          # @schema
+          # type: object
+          # @schema
           limits:
+            # @schema
+            # type: string
+            # @schema
             cpu: 100m
+            # @schema
+            # type: string
+            # @schema
             memory: 200Mi
+          # @schema
+          # type: object
+          # @schema
           requests:
+            # @schema
+            # type: string
+            # @schema
             cpu: 100m
+            # @schema
+            # type: string
+            # @schema
             memory: 160Mi
+  # @schema
+  # type: object
+  # @schema
   gpuPlugin:
+    # @schema
+    # type: object
+    # @schema
     chart:
+      # @schema
+      # type: string
+      # @schema
       repo: https://intel.github.io/helm-charts
+      # @schema
+      # type: string
+      # @schema
       name: intel-device-plugins-gpu
-      version: 0.36.0
+      # @schema
+      # type: string
+      # @schema
+      version: 0.32.0
+    # @schema
+    # type: object
+    # @schema
     release:
+      # @schema
+      # type: string
+      # @schema
       namespace: intel
+      # @schema
+      # additionalProperties: true
+      # @schema
       values:
+        # @schema
+        # type: integer
+        # @schema
         sharedDevNum: 1
+        # @schema
+        # type: string
+        # @schema
         preferredAllocationPolicy: none
+        # @schema
+        # type: integer
+        # @schema
         logLevel: 4
+        # @schema
+        # type: boolean
+        # @schema
         enableMonitoring: true
+        # @schema
+        # type: array
+        # @schema
         tolerations:
           - key: "gpu.intel.com/i915"
             operator: "Exists"
             effect: "NoSchedule"
+  # @schema
+  # type: object
+  # @schema
+  # xpuManagerMonitoring requires Flux CD source
+  # and kustomization controllers to be installed
+  # on the CAPI management cluster.
   xpuManagerMonitoring:
+    # @schema
+    # type: boolean
+    # @schema
     enabled: true
+    # @schema
+    # type: string
+    # @schema
     namespace: intel
+    # @schema
+    # type: object
+    # @schema
     repo:
+      # @schema
+      # type: string
+      # @schema
       url: https://github.com/intel/xpumanager
+      # @schema
+      # type: string
+      # @schema
       tag: V1.2.39
 
+# @schema
+# type: object
+# @schema
 certManager:
+  # @schema
+  # type: boolean
+  # @schema
   enabled: false
+  # @schema
+  # type: object
+  # @schema
   chart:
+    # @schema
+    # type: string
+    # @schema
     repo: https://charts.jetstack.io
+    # @schema
+    # type: string
+    # @schema
     name: cert-manager
+    # @schema
+    # type: string
+    # @schema
     version: v1.17.0
+  # @schema
+  # type: object
+  # @schema
   release:
+    # @schema
+    # type: string
+    # @schema
     namespace: cert-manager
+    # @schema
+    # additionalProperties: true
+    # @schema
     values:
+      # @schema
+      # type: object
+      # @schema
       crds:
+        # @schema
+        # type: boolean
+        # @schema
         enabled: true
 
+# @schema
+# type: object
+# @schema
 # Settings for the Mellanox network operator
 mellanoxNetworkOperator:
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates if the network operator should be enabled
   # Note that because it uses node feature discovery to run only on nodes
   # with a Mellanox NIC available, the overhead of enabling this on clusters
   # that do not need it now but may need it in the future is low
   enabled: true
+  # @schema
+  # type: object
+  # @schema
   chart:
+    # @schema
+    # type: string
+    # @schema
     repo: https://helm.ngc.nvidia.com/nvidia
+    # @schema
+    # type: string
+    # @schema
     name: network-operator
+    # @schema
+    # type: string
+    # @schema
     version: 26.1.1
+  # @schema
+  # type: object
+  # @schema
   release:
+    # @schema
+    # type: string
+    # @schema
     namespace: network-operator
+    # @schema
+    # additionalProperties: true
+    # @schema
     values: {}
 
+# @schema
+# type: object
+# @schema
 # Settings for the node problem detector
 nodeProblemDetector:
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates if the node problem detector should be enabled
   enabled: true
+  # @schema
+  # type: object
+  # @schema
   chart:
+    # @schema
+    # type: string
+    # @schema
     repo: https://charts.deliveryhero.io
+    # @schema
+    # type: string
+    # @schema
     name: node-problem-detector
+    # @schema
+    # type: string
+    # @schema
     version: 2.3.14
+  # @schema
+  # type: object
+  # @schema
   release:
+    # @schema
+    # type: string
+    # @schema
     namespace: node-problem-detector
+    # @schema
+    # additionalProperties: true
+    # @schema
     values: {}
 
 # Settings for any custom addons
+# @schema
+# type: object
+# patternProperties:
+#   ".*":
+#     oneOf:
+#       - type: object
+#         additionalProperties: false
+#         properties:
+#           kind:
+#             const: HelmRelease
+#           spec:
+#             properties:
+#               namespace:
+#                 type: string
+#               chart:
+#                 type: object
+#                 additionalProperties: false
+#                 properties:
+#                   repo:
+#                     type: string
+#                   name:
+#                     type: string
+#                   version:
+#                     type: string
+#               values:
+#                 type: object
+#                 additionalProperties: true
+#       - type: object
+#         additionalProperties: false
+#         properties:
+#           kind:
+#             const: Manifests
+#           spec:
+#             type: object
+#             additionalProperties: false
+#             properties:
+#               namespace:
+#                 type: string
+#               manifests:
+#                 type: object
+#                 patternProperties:
+#                   ".*":
+#                     type: string
+# @schema
 custom: {}
   # # Indexed by the name of the release on the target cluster
   # my-custom-helm-release:

--- a/charts/etcd-defrag/values.schema.json
+++ b/charts/etcd-defrag/values.schema.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "activeDeadlineSeconds": {
+      "default": 3600,
+      "title": "activeDeadlineSeconds",
+      "type": "integer"
+    },
+    "affinity": {
+      "additionalProperties": true,
+      "required": [],
+      "title": "affinity"
+    },
+    "backoffLimit": {
+      "default": 3,
+      "description": "Abandon the defrag after three retries or one hour, whichever is sooner",
+      "title": "backoffLimit",
+      "type": "integer"
+    },
+    "global": {
+      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+      "required": [],
+      "title": "global",
+      "type": "object"
+    },
+    "image": {
+      "additionalProperties": false,
+      "description": "The kubectl image to use\nNOTE: Image must also include a bash shell\neven if it's not the default entrypoint",
+      "properties": {
+        "pullPolicy": {
+          "default": "IfNotPresent",
+          "title": "pullPolicy",
+          "type": "string"
+        },
+        "repository": {
+          "default": "bitnami/kubectl",
+          "title": "repository",
+          "type": "string"
+        },
+        "tag": {
+          "default": "latest",
+          "title": "tag",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "image",
+      "type": "object"
+    },
+    "imagePullSecrets": {
+      "items": {
+        "required": []
+      },
+      "title": "imagePullSecrets",
+      "type": "array"
+    },
+    "nodeSelector": {
+      "additionalProperties": true,
+      "description": "Scheduling parameters for the kubectl pod",
+      "required": [],
+      "title": "nodeSelector"
+    },
+    "podSecurityContext": {
+      "additionalProperties": true,
+      "description": "Pod-level security context",
+      "properties": {
+        "runAsNonRoot": {
+          "default": true,
+          "title": "runAsNonRoot",
+          "type": "boolean"
+        }
+      },
+      "required": [],
+      "title": "podSecurityContext"
+    },
+    "resources": {
+      "additionalProperties": true,
+      "description": "Resources for the kubectl container",
+      "required": [],
+      "title": "resources"
+    },
+    "schedule": {
+      "default": "0 0 * * *",
+      "description": "The schedule for the cronjob (defaults to nightly)",
+      "title": "schedule",
+      "type": "string"
+    },
+    "securityContext": {
+      "additionalProperties": true,
+      "description": "Container-level security context",
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "default": false,
+          "title": "allowPrivilegeEscalation",
+          "type": "boolean"
+        },
+        "capabilities": {
+          "additionalProperties": true,
+          "properties": {
+            "drop": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  }
+                ],
+                "required": []
+              },
+              "title": "drop",
+              "type": "array"
+            }
+          },
+          "required": [],
+          "title": "capabilities"
+        },
+        "readOnlyRootFilesystem": {
+          "default": true,
+          "title": "readOnlyRootFilesystem",
+          "type": "boolean"
+        }
+      },
+      "required": [],
+      "title": "securityContext"
+    },
+    "startingDeadlineSeconds": {
+      "default": 43200,
+      "description": "Allow the jobs to start up to 12 hours after the configured time\nIf it does not start within this time, just wait for the next one",
+      "title": "startingDeadlineSeconds",
+      "type": "integer"
+    },
+    "tolerations": {
+      "description": "Allow the pods to run on control plane nodes if they need to",
+      "items": {
+        "additionalProperties": true,
+        "required": [],
+        "type": "object"
+      },
+      "title": "tolerations",
+      "type": "array"
+    }
+  },
+  "required": [],
+  "type": "object"
+}

--- a/charts/etcd-defrag/values.yaml
+++ b/charts/etcd-defrag/values.yaml
@@ -1,43 +1,107 @@
+# yaml-language-server: $schema=values.schema.json
+
+# @schema
+# type: string
+# @schema
 # The schedule for the cronjob (defaults to nightly)
 schedule: "0 0 * * *"
+# @schema
+# type: integer
+# @schema
 # Allow the jobs to start up to 12 hours after the configured time
 # If it does not start within this time, just wait for the next one
 startingDeadlineSeconds: 43200
 
+# @schema
+# type: integer
+# @schema
 # Abandon the defrag after three retries or one hour, whichever is sooner
 backoffLimit: 3
+# @schema
+# type: integer
+# @schema
 activeDeadlineSeconds: 3600
 
+# @schema
+# type: object
+# @schema
 # The kubectl image to use
 # NOTE: Image must also include a bash shell
 # even if it's not the default entrypoint
 image:
+  # @schema
+  # type: string
+  # @schema
   repository: bitnami/kubectl
+  # @schema
+  # type: string
+  # @schema
   pullPolicy: IfNotPresent
+  # @schema
+  # type: string
+  # @schema
   tag: latest
 
+# @schema
+# type: array
+# @schema
 imagePullSecrets: []
 
 # Pod-level security context
+# @schema
+# additionalProperties: true
+# @schema
 podSecurityContext:
+  # @schema
+  # type: boolean
+  # @schema
   runAsNonRoot: true
 
 # Container-level security context
+# @schema
+# additionalProperties: true
+# @schema
 securityContext:
+  # @schema
+  # type: boolean
+  # @schema
   allowPrivilegeEscalation: false
   capabilities:
+    # @schema
+    # type: array
+    # @schema
     drop: [ALL]
+  # @schema
+  # type: boolean
+  # @schema
   readOnlyRootFilesystem: true
 
 # Resources for the kubectl container
+# @schema
+# additionalProperties: true
+# @schema
 resources: {}
 
 # Scheduling parameters for the kubectl pod
+# @schema
+# additionalProperties: true
+# @schema
 nodeSelector: {}
+
 # Allow the pods to run on control plane nodes if they need to
+# @schema
+# type: array
+# items:
+#   type: object
+#   additionalProperties: true
+# @schema
 tolerations:
   - key: node-role.kubernetes.io/master
     effect: NoSchedule
   - key: node-role.kubernetes.io/control-plane
     effect: NoSchedule
+
+# @schema
+# additionalProperties: true
+# @schema
 affinity: {}

--- a/charts/etcd-defrag/values.yaml
+++ b/charts/etcd-defrag/values.yaml
@@ -66,6 +66,9 @@ securityContext:
   # type: boolean
   # @schema
   allowPrivilegeEscalation: false
+  # @schema
+  # additionalProperties: true
+  # @schema
   capabilities:
     # @schema
     # type: array

--- a/charts/openstack-cluster/tests/__snapshot__/snapshot_full_test.yaml.snap
+++ b/charts/openstack-cluster/tests/__snapshot__/snapshot_full_test.yaml.snap
@@ -502,7 +502,7 @@ templated manifests should match snapshot:
       chart:
         name: intel-device-plugins-gpu
         repo: https://intel.github.io/helm-charts
-        version: 0.36.0
+        version: 0.32.0
       clusterName: RELEASE-NAME
       releaseName: intel-device-plugin-gpu
       targetNamespace: intel

--- a/charts/openstack-cluster/tests/values_full.yaml
+++ b/charts/openstack-cluster/tests/values_full.yaml
@@ -29,7 +29,7 @@ addons:
       enabled: true
     k8sKeystoneAuth:
       enabled: true
-  etcDefrag:
+  etcdDefrag:
     enabled: true
   metricsServer:
     enabled: true

--- a/charts/openstack-cluster/values.schema.json
+++ b/charts/openstack-cluster/values.schema.json
@@ -13,6 +13,61 @@
     "addons": {
       "description": "Helm chart that deploys cluster addons for a CAPI cluster.",
       "properties": {
+        "amdGPUOperator": {
+          "additionalProperties": false,
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "gpu-operator-charts",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://rocm.github.io/gpu-operator",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "v1.5.0",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "enabled": {
+              "default": false,
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "kube-amd-gpu",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": false,
+                  "required": [],
+                  "title": "values",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "amdGPUOperator",
+          "type": "object"
+        },
         "certManager": {
           "additionalProperties": false,
           "properties": {
@@ -53,7 +108,7 @@
                   "type": "string"
                 },
                 "values": {
-                  "additionalProperties": false,
+                  "additionalProperties": true,
                   "properties": {
                     "crds": {
                       "additionalProperties": false,
@@ -70,8 +125,7 @@
                     }
                   },
                   "required": [],
-                  "title": "values",
-                  "type": "object"
+                  "title": "values"
                 }
               },
               "required": [],
@@ -86,8 +140,12 @@
         "clusterName": {
           "default": "",
           "description": "The name of the Cluster API cluster\nif not given, the release name is used",
+          "required": [],
           "title": "clusterName",
-          "type": "null"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "cni": {
           "additionalProperties": false,
@@ -201,7 +259,7 @@
                       "type": "string"
                     },
                     "values": {
-                      "additionalProperties": false,
+                      "additionalProperties": true,
                       "properties": {
                         "nodeSelector": {
                           "additionalProperties": false,
@@ -218,8 +276,7 @@
                         }
                       },
                       "required": [],
-                      "title": "values",
-                      "type": "object"
+                      "title": "values"
                     }
                   },
                   "required": [],
@@ -267,10 +324,9 @@
                       "type": "string"
                     },
                     "values": {
-                      "additionalProperties": false,
+                      "additionalProperties": true,
                       "required": [],
-                      "title": "values",
-                      "type": "object"
+                      "title": "values"
                     }
                   },
                   "required": [],
@@ -291,8 +347,12 @@
             "type": {
               "default": "calico",
               "description": "The CNI to deploy - supported values are calico or cilium",
-              "title": "type",
-              "type": "string"
+              "enum": [
+                "calico",
+                "cilium"
+              ],
+              "required": [],
+              "title": "type"
             }
           },
           "required": [],
@@ -344,10 +404,9 @@
                       "type": "string"
                     },
                     "values": {
-                      "additionalProperties": false,
+                      "additionalProperties": true,
                       "required": [],
-                      "title": "values",
-                      "type": "object"
+                      "title": "values"
                     }
                   },
                   "required": [],
@@ -365,14 +424,92 @@
           "type": "object"
         },
         "custom": {
-          "additionalProperties": true,
+          "additionalProperties": false,
           "description": "Settings for any custom addons",
+          "patternProperties": {
+            ".*": {
+              "oneOf": [
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "kind": {
+                      "const": "HelmRelease",
+                      "required": []
+                    },
+                    "spec": {
+                      "properties": {
+                        "chart": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "repo": {
+                              "type": "string"
+                            },
+                            "version": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [],
+                          "type": "object"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        },
+                        "values": {
+                          "additionalProperties": true,
+                          "required": [],
+                          "type": "object"
+                        }
+                      },
+                      "required": []
+                    }
+                  },
+                  "required": [],
+                  "type": "object"
+                },
+                {
+                  "additionalProperties": false,
+                  "properties": {
+                    "kind": {
+                      "const": "Manifests",
+                      "required": []
+                    },
+                    "spec": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "manifests": {
+                          "patternProperties": {
+                            ".*": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [],
+                          "type": "object"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "type": "object"
+                }
+              ],
+              "required": []
+            }
+          },
           "required": [],
           "title": "custom",
           "type": "object"
         },
         "enabled": {
-          "description": "Conditional property used in parent chart",
+          "default": true,
+          "description": "Included for schema validation purposes.\nHas no effect unless this chart is used\nas a conditional dependency of the\nopenstack-cluster chart.",
           "title": "enabled",
           "type": "boolean"
         },
@@ -395,8 +532,12 @@
                 },
                 "version": {
                   "default": "",
+                  "required": [],
                   "title": "version",
-                  "type": "null"
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 }
               },
               "required": [],
@@ -419,10 +560,9 @@
                   "type": "string"
                 },
                 "values": {
-                  "additionalProperties": false,
+                  "additionalProperties": true,
                   "required": [],
-                  "title": "values",
-                  "type": "object"
+                  "title": "values"
                 }
               },
               "required": [],
@@ -492,10 +632,9 @@
                       "type": "string"
                     },
                     "values": {
-                      "additionalProperties": false,
+                      "additionalProperties": true,
                       "required": [],
-                      "title": "values",
-                      "type": "object"
+                      "title": "values"
                     }
                   },
                   "required": [],
@@ -612,7 +751,7 @@
                       "type": "string"
                     },
                     "values": {
-                      "additionalProperties": false,
+                      "additionalProperties": true,
                       "properties": {
                         "enableMonitoring": {
                           "default": true,
@@ -667,8 +806,7 @@
                         }
                       },
                       "required": [],
-                      "title": "values",
-                      "type": "object"
+                      "title": "values"
                     }
                   },
                   "required": [],
@@ -715,7 +853,7 @@
                       "type": "string"
                     },
                     "values": {
-                      "additionalProperties": false,
+                      "additionalProperties": true,
                       "properties": {
                         "manager": {
                           "additionalProperties": false,
@@ -784,8 +922,7 @@
                         }
                       },
                       "required": [],
-                      "title": "values",
-                      "type": "object"
+                      "title": "values"
                     }
                   },
                   "required": [],
@@ -799,6 +936,7 @@
             },
             "xpuManagerMonitoring": {
               "additionalProperties": false,
+              "description": "xpuManagerMonitoring requires Flux CD source\nand kustomization controllers to be installed\non the CAPI management cluster.",
               "properties": {
                 "enabled": {
                   "default": true,
@@ -880,10 +1018,9 @@
                   "type": "string"
                 },
                 "values": {
-                  "additionalProperties": false,
+                  "additionalProperties": true,
                   "required": [],
-                  "title": "values",
-                  "type": "object"
+                  "title": "values"
                 }
               },
               "required": [],
@@ -937,10 +1074,9 @@
                   "type": "string"
                 },
                 "values": {
-                  "additionalProperties": false,
+                  "additionalProperties": true,
                   "required": [],
-                  "title": "values",
-                  "type": "object"
+                  "title": "values"
                 }
               },
               "required": [],
@@ -990,7 +1126,7 @@
                 },
                 "openstackAuthUrlTarget": {
                   "additionalProperties": false,
-                  "description": "Indicates if a blackbox target for the cloud's auth endpoint should be created",
+                  "description": "Example of adding additional scrape targets\nserviceMonitor:\n  targets:\n    - name: example\n      url: http://example.com/healthz\nIndicates if a blackbox target for the cloud's auth endpoint should be created",
                   "properties": {
                     "enabled": {
                       "default": true,
@@ -1011,10 +1147,9 @@
                       "type": "string"
                     },
                     "values": {
-                      "additionalProperties": false,
+                      "additionalProperties": true,
                       "required": [],
-                      "title": "values",
-                      "type": "object"
+                      "title": "values"
                     }
                   },
                   "required": [],
@@ -1068,7 +1203,7 @@
                       "type": "string"
                     },
                     "values": {
-                      "additionalProperties": false,
+                      "additionalProperties": true,
                       "properties": {
                         "alertmanager": {
                           "additionalProperties": false,
@@ -1231,8 +1366,7 @@
                         }
                       },
                       "required": [],
-                      "title": "values",
-                      "type": "object"
+                      "title": "values"
                     }
                   },
                   "required": [],
@@ -1246,6 +1380,7 @@
             },
             "lokiStack": {
               "additionalProperties": false,
+              "deprecated": true,
               "properties": {
                 "chart": {
                   "additionalProperties": false,
@@ -1284,7 +1419,7 @@
                       "type": "string"
                     },
                     "values": {
-                      "additionalProperties": false,
+                      "additionalProperties": true,
                       "properties": {
                         "loki": {
                           "additionalProperties": false,
@@ -1350,8 +1485,7 @@
                         }
                       },
                       "required": [],
-                      "title": "values",
-                      "type": "object"
+                      "title": "values"
                     }
                   },
                   "required": [],
@@ -1360,8 +1494,7 @@
                 }
               },
               "required": [],
-              "title": "lokiStack",
-              "type": "object"
+              "title": "lokiStack"
             }
           },
           "required": [],
@@ -1410,10 +1543,9 @@
                   "type": "string"
                 },
                 "values": {
-                  "additionalProperties": false,
+                  "additionalProperties": true,
                   "required": [],
-                  "title": "values",
-                  "type": "object"
+                  "title": "values"
                 }
               },
               "required": [],
@@ -1467,10 +1599,9 @@
                   "type": "string"
                 },
                 "values": {
-                  "additionalProperties": false,
+                  "additionalProperties": true,
                   "required": [],
-                  "title": "values",
-                  "type": "object"
+                  "title": "values"
                 }
               },
               "required": [],
@@ -1524,7 +1655,7 @@
                   "type": "string"
                 },
                 "values": {
-                  "additionalProperties": false,
+                  "additionalProperties": true,
                   "properties": {
                     "dcgmExporter": {
                       "additionalProperties": false,
@@ -1549,8 +1680,7 @@
                     }
                   },
                   "required": [],
-                  "title": "values",
-                  "type": "object"
+                  "title": "values"
                 }
               },
               "required": [],
@@ -1600,10 +1730,9 @@
                   "type": "boolean"
                 },
                 "values": {
-                  "additionalProperties": false,
+                  "additionalProperties": true,
                   "required": [],
-                  "title": "values",
-                  "type": "object"
+                  "title": "values"
                 }
               },
               "required": [],
@@ -1679,10 +1808,15 @@
                       "type": "boolean"
                     },
                     "allowedTopologies": {
+                      "additionalProperties": true,
                       "default": "",
                       "description": "The allowed topologies for the storage class",
+                      "required": [],
                       "title": "allowedTopologies",
-                      "type": "null"
+                      "type": [
+                        "object",
+                        "null"
+                      ]
                     },
                     "availabilityZone": {
                       "default": "nova",
@@ -1699,8 +1833,12 @@
                     "fstype": {
                       "default": "",
                       "description": "Filesystem type to use for volumes provisioned with the storage class\nIf not given, the default filesystem type will be used",
+                      "required": [],
                       "title": "fstype",
-                      "type": "null"
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "isClusterDefault": {
                       "default": true,
@@ -1729,6 +1867,7 @@
                     "volumeType": {
                       "default": "",
                       "description": "The Cinder volume type to use for volumes provisioned by the storage class\nIf not given, the default volume type will be used",
+                      "required": [],
                       "title": "volumeType",
                       "type": [
                         "string",
@@ -1747,7 +1886,7 @@
                   "type": "boolean"
                 },
                 "values": {
-                  "additionalProperties": false,
+                  "additionalProperties": true,
                   "properties": {
                     "csi": {
                       "additionalProperties": false,
@@ -1814,8 +1953,7 @@
                     }
                   },
                   "required": [],
-                  "title": "values",
-                  "type": "object"
+                  "title": "values"
                 }
               },
               "required": [],
@@ -1870,8 +2008,12 @@
                     "allowedTopologies": {
                       "default": "",
                       "description": "The allowed topologies for the storage class",
+                      "required": [],
                       "title": "allowedTopologies",
-                      "type": "null"
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "enabled": {
                       "default": true,
@@ -1892,25 +2034,32 @@
                       "type": "string"
                     },
                     "parameters": {
-                      "additionalProperties": false,
+                      "additionalProperties": true,
                       "description": "The parameters for the storage class\nSee https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/manila-csi-plugin/using-manila-csi-plugin.md#controller-service-volume-parameters",
                       "properties": {
                         "type": {
                           "default": "",
                           "description": "The Manila share type to use\nIf not given and the Ceph CSI plugin is installed, cephfs is used",
+                          "required": [],
                           "title": "type",
-                          "type": "null"
+                          "type": [
+                            "string",
+                            "null"
+                          ]
                         }
                       },
                       "required": [],
-                      "title": "parameters",
-                      "type": "object"
+                      "title": "parameters"
                     },
                     "provisioner": {
                       "default": "",
                       "description": "The provisioner for the storage class\nIf not given and the Ceph CSI plugin is installed, cephfs.manila.csi.openstack.org is used",
+                      "required": [],
                       "title": "provisioner",
-                      "type": "null"
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "reclaimPolicy": {
                       "default": "Delete",
@@ -1936,10 +2085,9 @@
                   "type": "boolean"
                 },
                 "values": {
-                  "additionalProperties": false,
+                  "additionalProperties": true,
                   "required": [],
-                  "title": "values",
-                  "type": "object"
+                  "title": "values"
                 }
               },
               "required": [],
@@ -2047,7 +2195,7 @@
                   "type": "string"
                 },
                 "values": {
-                  "additionalProperties": false,
+                  "additionalProperties": true,
                   "properties": {
                     "reloader": {
                       "additionalProperties": false,
@@ -2065,8 +2213,7 @@
                     }
                   },
                   "required": [],
-                  "title": "values",
-                  "type": "object"
+                  "title": "values"
                 }
               },
               "required": [],
@@ -2099,26 +2246,18 @@
           ]
         },
         "allowedCIDRs": {
-          "default": [],
-          "description": "Restrict loadbalancer access to select IPs",
-          "required": [],
-          "title": "allowedCIDRs",
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "associateFloatingIP": {
-          "default": "true",
-          "description": "Restrict loadbalancer access to select IPs\nallowedCidrs:\n - 192.168.0.0/16  # needed for cluster to init\n - 10.10.0.0/16  # IPv4 Internal Network\n - 123.123.123.123 # some other IPs\nIndicates whether to associate a floating IP with the API server",
+          "description": "Restrict loadbalancer access to select IPs\nallowedCidrs:\n - 192.168.0.0/16  # needed for cluster to init\n - 10.10.0.0/16  # IPv4 Internal Network\n - 123.123.123.123 # some other IPs",
           "items": {
             "type": "string"
           },
-          "required": [],
+          "title": "allowedCIDRs",
+          "type": "array"
+        },
+        "associateFloatingIP": {
+          "default": true,
+          "description": "Indicates whether to associate a floating IP with the API server",
           "title": "associateFloatingIP",
-          "type": [
-            "boolean"
-          ]
+          "type": "boolean"
         },
         "enableLoadBalancer": {
           "default": true,
@@ -2519,17 +2658,19 @@
           "title": "allowAllInClusterTraffic",
           "type": "boolean"
         },
+        "controlPlaneNodesSecurityGroupRules": {
+          "description": "Defines the rules that should be applied to control plane nodes.",
+          "items": {
+            "required": []
+          },
+          "title": "controlPlaneNodesSecurityGroupRules",
+          "type": "array"
+        },
         "disableExternalNetwork": {
           "default": false,
           "description": "Custom nameservers to use for the hosts\nDeprecated; use `clusterNetworking.internalNetwork.dnsNameservers` instead.\ndnsNameservers: []\nIndicates whether or not to attempt to connect the cluster to an external\nnetwork.",
           "title": "disableExternalNetwork",
           "type": "boolean"
-        },
-        "controlPlaneNodesSecurityGroupRules": {
-          "default": [],
-          "description": "A list of security groups to apply to worker nodes when OVN is the apiserver loadbalancer provider",
-          "title": "controlPlaneNodesSecurityGroupRules",
-          "type": "array"
         },
         "externalNetworkId": {
           "default": "",
@@ -2620,10 +2761,12 @@
           "title": "manageSecurityGroups",
           "type": "boolean"
         },
-        "workerNodeSecurityGroupRules": {
-          "default": [],
-          "description": "A list of security groups to apply to worker nodes when OVN is the apiserver loadbalancer provider",
-          "title": "workerNodeSecurityGroupRules",
+        "workerNodesSecurityGroupRules": {
+          "description": "Defines the rules that should be applied to worker nodes.",
+          "items": {
+            "required": []
+          },
+          "title": "workerNodesSecurityGroupRules",
           "type": "array"
         }
       },

--- a/charts/openstack-cluster/values.schema.json
+++ b/charts/openstack-cluster/values.schema.json
@@ -365,7 +365,7 @@
           "type": "object"
         },
         "custom": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "Settings for any custom addons",
           "required": [],
           "title": "custom",

--- a/charts/openstack-cluster/values.schema.json
+++ b/charts/openstack-cluster/values.schema.json
@@ -1,0 +1,3745 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "additionalPackages": {
+      "description": "List of additional packages to install on cluster nodes",
+      "items": {
+        "type": "string"
+      },
+      "title": "additionalPackages",
+      "type": "array"
+    },
+    "addons": {
+      "description": "Helm chart that deploys cluster addons for a CAPI cluster.",
+      "properties": {
+        "certManager": {
+          "additionalProperties": false,
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "cert-manager",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://charts.jetstack.io",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "v1.17.0",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "enabled": {
+              "default": false,
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "cert-manager",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "crds": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "enabled": {
+                          "default": true,
+                          "title": "enabled",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [],
+                      "title": "crds",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "values",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "certManager",
+          "type": "object"
+        },
+        "clusterName": {
+          "default": "",
+          "description": "The name of the Cluster API cluster\nif not given, the release name is used",
+          "title": "clusterName",
+          "type": "null"
+        },
+        "cni": {
+          "additionalProperties": false,
+          "description": "Settings for the CNI addon",
+          "properties": {
+            "calico": {
+              "additionalProperties": false,
+              "description": "Settings for the calico CNI\nSee https://projectcalico.docs.tigera.io/getting-started/kubernetes/helm",
+              "properties": {
+                "chart": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "default": "tigera-operator",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "repo": {
+                      "default": "https://projectcalico.docs.tigera.io/charts",
+                      "title": "repo",
+                      "type": "string"
+                    },
+                    "version": {
+                      "default": "v3.31.5",
+                      "title": "version",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "chart",
+                  "type": "object"
+                },
+                "globalNetworkPolicy": {
+                  "additionalProperties": false,
+                  "description": "Nova metadata service\nSee https://docs.openstack.org/nova/latest/user/metadata.html#the-metadata-service",
+                  "properties": {
+                    "allowEgressCidrs": {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "required": []
+                      },
+                      "title": "allowEgressCidrs",
+                      "type": "array"
+                    },
+                    "allowPriority": {
+                      "default": 20,
+                      "title": "allowPriority",
+                      "type": "integer"
+                    },
+                    "allowv6EgressCidrs": {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "required": []
+                      },
+                      "title": "allowv6EgressCidrs",
+                      "type": "array"
+                    },
+                    "denyEgressCidrs": {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "required": []
+                      },
+                      "title": "denyEgressCidrs",
+                      "type": "array"
+                    },
+                    "denyNamespaceSelector": {
+                      "default": "kubernetes.io/metadata.name != 'openstack-system'",
+                      "title": "denyNamespaceSelector",
+                      "type": "string"
+                    },
+                    "denyPriority": {
+                      "default": 10,
+                      "title": "denyPriority",
+                      "type": "integer"
+                    },
+                    "denyv6EgressCidrs": {
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "required": []
+                      },
+                      "title": "denyv6EgressCidrs",
+                      "type": "array"
+                    }
+                  },
+                  "required": [],
+                  "title": "globalNetworkPolicy",
+                  "type": "object"
+                },
+                "release": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "namespace": {
+                      "default": "tigera-operator",
+                      "title": "namespace",
+                      "type": "string"
+                    },
+                    "values": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "nodeSelector": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "node-role.kubernetes.io/control-plane": {
+                              "default": "",
+                              "title": "node-role.kubernetes.io/control-plane",
+                              "type": "string"
+                            }
+                          },
+                          "required": [],
+                          "title": "nodeSelector",
+                          "type": "object"
+                        }
+                      },
+                      "required": [],
+                      "title": "values",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "release",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "calico",
+              "type": "object"
+            },
+            "cilium": {
+              "additionalProperties": false,
+              "description": "Settings for the Cilium CNI\nSee https://docs.cilium.io/en/stable/gettingstarted/k8s-install-helm/ for details",
+              "properties": {
+                "chart": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "default": "cilium",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "repo": {
+                      "default": "https://helm.cilium.io/",
+                      "title": "repo",
+                      "type": "string"
+                    },
+                    "version": {
+                      "default": "1.19.3",
+                      "title": "version",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "chart",
+                  "type": "object"
+                },
+                "release": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "namespace": {
+                      "default": "kube-system",
+                      "title": "namespace",
+                      "type": "string"
+                    },
+                    "values": {
+                      "additionalProperties": false,
+                      "required": [],
+                      "title": "values",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "release",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "cilium",
+              "type": "object"
+            },
+            "enabled": {
+              "default": true,
+              "description": "Indicates if a CNI should be deployed",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "type": {
+              "default": "calico",
+              "description": "The CNI to deploy - supported values are calico or cilium",
+              "title": "type",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "cni",
+          "type": "object"
+        },
+        "csi": {
+          "additionalProperties": false,
+          "description": "Settings for CSI addons",
+          "properties": {
+            "cephfs": {
+              "additionalProperties": false,
+              "description": "Settings for the CephFS CSI",
+              "properties": {
+                "chart": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "default": "ceph-csi-cephfs",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "repo": {
+                      "default": "https://ceph.github.io/csi-charts",
+                      "title": "repo",
+                      "type": "string"
+                    },
+                    "version": {
+                      "default": "3.11.0",
+                      "title": "version",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "chart",
+                  "type": "object"
+                },
+                "enabled": {
+                  "default": false,
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "release": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "namespace": {
+                      "default": "csi-ceph-system",
+                      "title": "namespace",
+                      "type": "string"
+                    },
+                    "values": {
+                      "additionalProperties": false,
+                      "required": [],
+                      "title": "values",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "release",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "cephfs",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "csi",
+          "type": "object"
+        },
+        "custom": {
+          "additionalProperties": false,
+          "description": "Settings for any custom addons",
+          "required": [],
+          "title": "custom",
+          "type": "object"
+        },
+        "enabled": {
+          "description": "Conditional property used in parent chart",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "etcdDefrag": {
+          "additionalProperties": false,
+          "description": "Settings for etcd defragmentation jobs",
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "etcd-defrag",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://azimuth-cloud.github.io/capi-helm-charts",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "",
+                  "title": "version",
+                  "type": "null"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "enabled": {
+              "default": true,
+              "description": "Indicates if the etcd defragmentation job should be enabled",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "kube-system",
+                  "description": "This should be namespace in which the etcd pods are deployed",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": false,
+                  "required": [],
+                  "title": "values",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "etcdDefrag",
+          "type": "object"
+        },
+        "global": {
+          "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+          "required": [],
+          "title": "global",
+          "type": "object"
+        },
+        "ingress": {
+          "additionalProperties": false,
+          "description": "Settings for ingress controllers",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Indicates if ingress controllers should be enabled",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "nginx": {
+              "additionalProperties": false,
+              "description": "Settings for the Nginx ingress controller\nhttps://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx#configuration",
+              "properties": {
+                "chart": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "default": "ingress-nginx",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "repo": {
+                      "default": "https://kubernetes.github.io/ingress-nginx",
+                      "title": "repo",
+                      "type": "string"
+                    },
+                    "version": {
+                      "default": "4.15.1",
+                      "title": "version",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "chart",
+                  "type": "object"
+                },
+                "enabled": {
+                  "default": false,
+                  "description": "Indicates if the Nginx ingress controller should be enabled",
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "release": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "namespace": {
+                      "default": "ingress-nginx",
+                      "title": "namespace",
+                      "type": "string"
+                    },
+                    "values": {
+                      "additionalProperties": false,
+                      "required": [],
+                      "title": "values",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "release",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "nginx",
+              "type": "object"
+            },
+            "traefik": {
+              "additionalProperties": false,
+              "description": "Settings for the Traefik ingress controller\nhttps://github.com/traefik/traefik-helm-chart/blob/master/EXAMPLES.md",
+              "properties": {
+                "chart": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "default": "traefik",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "repo": {
+                      "default": "https://traefik.github.io/charts",
+                      "title": "repo",
+                      "type": "string"
+                    },
+                    "version": {
+                      "default": "40.1.0",
+                      "title": "version",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "chart",
+                  "type": "object"
+                },
+                "enabled": {
+                  "default": true,
+                  "description": "Indicates if the Traefik ingress controller should be enabled\nThe Traefik ingress controller is enabled by default if ingress controllers are enabled",
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "release": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "namespace": {
+                      "default": "traefik",
+                      "title": "namespace",
+                      "type": "string"
+                    },
+                    "values": {
+                      "additionalProperties": false,
+                      "required": [],
+                      "title": "values",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "release",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "traefik",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "ingress",
+          "type": "object"
+        },
+        "intelDevicePlugin": {
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "default": false,
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "gpuPlugin": {
+              "additionalProperties": false,
+              "properties": {
+                "chart": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "default": "intel-device-plugins-gpu",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "repo": {
+                      "default": "https://intel.github.io/helm-charts",
+                      "title": "repo",
+                      "type": "string"
+                    },
+                    "version": {
+                      "default": "0.32.0",
+                      "title": "version",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "chart",
+                  "type": "object"
+                },
+                "release": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "namespace": {
+                      "default": "intel",
+                      "title": "namespace",
+                      "type": "string"
+                    },
+                    "values": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "enableMonitoring": {
+                          "default": true,
+                          "title": "enableMonitoring",
+                          "type": "boolean"
+                        },
+                        "logLevel": {
+                          "default": 4,
+                          "title": "logLevel",
+                          "type": "integer"
+                        },
+                        "preferredAllocationPolicy": {
+                          "default": "none",
+                          "title": "preferredAllocationPolicy",
+                          "type": "string"
+                        },
+                        "sharedDevNum": {
+                          "default": 1,
+                          "title": "sharedDevNum",
+                          "type": "integer"
+                        },
+                        "tolerations": {
+                          "items": {
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "effect": {
+                                    "default": "NoSchedule",
+                                    "title": "effect",
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "default": "gpu.intel.com/i915",
+                                    "title": "key",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "default": "Exists",
+                                    "title": "operator",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [],
+                                "type": "object"
+                              }
+                            ],
+                            "required": []
+                          },
+                          "title": "tolerations",
+                          "type": "array"
+                        }
+                      },
+                      "required": [],
+                      "title": "values",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "release",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "gpuPlugin",
+              "type": "object"
+            },
+            "operator": {
+              "additionalProperties": false,
+              "properties": {
+                "chart": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "default": "intel-device-plugins-operator",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "repo": {
+                      "default": "https://intel.github.io/helm-charts",
+                      "title": "repo",
+                      "type": "string"
+                    },
+                    "version": {
+                      "default": "0.32.0",
+                      "title": "version",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "chart",
+                  "type": "object"
+                },
+                "release": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "namespace": {
+                      "default": "intel",
+                      "title": "namespace",
+                      "type": "string"
+                    },
+                    "values": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "manager": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "devices": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "gpu": {
+                                  "default": true,
+                                  "title": "gpu",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [],
+                              "title": "devices",
+                              "type": "object"
+                            }
+                          },
+                          "required": [],
+                          "title": "manager",
+                          "type": "object"
+                        },
+                        "resources": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "limits": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "cpu": {
+                                  "default": "100m",
+                                  "title": "cpu",
+                                  "type": "string"
+                                },
+                                "memory": {
+                                  "default": "200Mi",
+                                  "title": "memory",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [],
+                              "title": "limits",
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "cpu": {
+                                  "default": "100m",
+                                  "title": "cpu",
+                                  "type": "string"
+                                },
+                                "memory": {
+                                  "default": "160Mi",
+                                  "title": "memory",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [],
+                              "title": "requests",
+                              "type": "object"
+                            }
+                          },
+                          "required": [],
+                          "title": "resources",
+                          "type": "object"
+                        }
+                      },
+                      "required": [],
+                      "title": "values",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "release",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "operator",
+              "type": "object"
+            },
+            "xpuManagerMonitoring": {
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "default": true,
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "namespace": {
+                  "default": "intel",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "repo": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "tag": {
+                      "default": "V1.2.39",
+                      "title": "tag",
+                      "type": "string"
+                    },
+                    "url": {
+                      "default": "https://github.com/intel/xpumanager",
+                      "title": "url",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "repo",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "xpuManagerMonitoring",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "intelDevicePlugin",
+          "type": "object"
+        },
+        "mellanoxNetworkOperator": {
+          "additionalProperties": false,
+          "description": "Settings for the Mellanox network operator",
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "network-operator",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://helm.ngc.nvidia.com/nvidia",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "26.1.1",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "enabled": {
+              "default": true,
+              "description": "Indicates if the network operator should be enabled\nNote that because it uses node feature discovery to run only on nodes\nwith a Mellanox NIC available, the overhead of enabling this on clusters\nthat do not need it now but may need it in the future is low",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "network-operator",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": false,
+                  "required": [],
+                  "title": "values",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "mellanoxNetworkOperator",
+          "type": "object"
+        },
+        "metricsServer": {
+          "additionalProperties": false,
+          "description": "Settings for the metrics server\nhttps://github.com/kubernetes-sigs/metrics-server#helm-chart",
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "metrics-server",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://kubernetes-sigs.github.io/metrics-server",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "3.13.0",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "enabled": {
+              "default": true,
+              "description": "Indicates if the metrics server should be deployed",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "kube-system",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": false,
+                  "required": [],
+                  "title": "values",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "metricsServer",
+          "type": "object"
+        },
+        "monitoring": {
+          "additionalProperties": false,
+          "description": "Settings for cluster monitoring",
+          "properties": {
+            "blackboxExporter": {
+              "additionalProperties": false,
+              "description": "Configuration for the blackbox exporter",
+              "properties": {
+                "chart": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "default": "prometheus-blackbox-exporter",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "repo": {
+                      "default": "https://prometheus-community.github.io/helm-charts",
+                      "title": "repo",
+                      "type": "string"
+                    },
+                    "version": {
+                      "default": "11.9.1",
+                      "title": "version",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "chart",
+                  "type": "object"
+                },
+                "enabled": {
+                  "default": true,
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "openstackAuthUrlTarget": {
+                  "additionalProperties": false,
+                  "description": "Indicates if a blackbox target for the cloud's auth endpoint should be created",
+                  "properties": {
+                    "enabled": {
+                      "default": true,
+                      "title": "enabled",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [],
+                  "title": "openstackAuthUrlTarget",
+                  "type": "object"
+                },
+                "release": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "namespace": {
+                      "default": "monitoring-system",
+                      "title": "namespace",
+                      "type": "string"
+                    },
+                    "values": {
+                      "additionalProperties": false,
+                      "required": [],
+                      "title": "values",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "release",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "blackboxExporter",
+              "type": "object"
+            },
+            "enabled": {
+              "default": false,
+              "description": "Indicates if the cluster monitoring should be enabled",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "kubePrometheusStack": {
+              "additionalProperties": false,
+              "description": "Config for the kube-prometheus-stack helm chart\nhttps://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack",
+              "properties": {
+                "chart": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "default": "kube-prometheus-stack",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "repo": {
+                      "default": "https://prometheus-community.github.io/helm-charts",
+                      "title": "repo",
+                      "type": "string"
+                    },
+                    "version": {
+                      "default": "85.0.2",
+                      "title": "version",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "chart",
+                  "type": "object"
+                },
+                "release": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "namespace": {
+                      "default": "monitoring-system",
+                      "title": "namespace",
+                      "type": "string"
+                    },
+                    "values": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "alertmanager": {
+                          "additionalProperties": false,
+                          "description": "Enable persistence by default for prometheus and alertmanager",
+                          "properties": {
+                            "alertmanagerSpec": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "retention": {
+                                  "default": "168h",
+                                  "description": "By default, retain 7 days of data",
+                                  "title": "retention",
+                                  "type": "string"
+                                },
+                                "storage": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "volumeClaimTemplate": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "spec": {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "accessModes": {
+                                              "items": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "required": []
+                                              },
+                                              "title": "accessModes",
+                                              "type": "array"
+                                            },
+                                            "resources": {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "requests": {
+                                                  "additionalProperties": false,
+                                                  "properties": {
+                                                    "storage": {
+                                                      "default": "10Gi",
+                                                      "title": "storage",
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [],
+                                                  "title": "requests",
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "required": [],
+                                              "title": "resources",
+                                              "type": "object"
+                                            }
+                                          },
+                                          "required": [],
+                                          "title": "spec",
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [],
+                                      "title": "volumeClaimTemplate",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "required": [],
+                                  "title": "storage",
+                                  "type": "object"
+                                }
+                              },
+                              "required": [],
+                              "title": "alertmanagerSpec",
+                              "type": "object"
+                            }
+                          },
+                          "required": [],
+                          "title": "alertmanager",
+                          "type": "object"
+                        },
+                        "prometheus": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "prometheusSpec": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "retention": {
+                                  "default": "90d",
+                                  "description": "The amount of data that is retained will be 90 days or 95% of the size of the\npersistent volume, whichever is reached first",
+                                  "title": "retention",
+                                  "type": "string"
+                                },
+                                "storageSpec": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "volumeClaimTemplate": {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "spec": {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "accessModes": {
+                                              "items": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "required": []
+                                              },
+                                              "title": "accessModes",
+                                              "type": "array"
+                                            },
+                                            "resources": {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "requests": {
+                                                  "additionalProperties": false,
+                                                  "properties": {
+                                                    "storage": {
+                                                      "default": "10Gi",
+                                                      "title": "storage",
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [],
+                                                  "title": "requests",
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "required": [],
+                                              "title": "resources",
+                                              "type": "object"
+                                            }
+                                          },
+                                          "required": [],
+                                          "title": "spec",
+                                          "type": "object"
+                                        }
+                                      },
+                                      "required": [],
+                                      "title": "volumeClaimTemplate",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "required": [],
+                                  "title": "storageSpec",
+                                  "type": "object"
+                                }
+                              },
+                              "required": [],
+                              "title": "prometheusSpec",
+                              "type": "object"
+                            }
+                          },
+                          "required": [],
+                          "title": "prometheus",
+                          "type": "object"
+                        }
+                      },
+                      "required": [],
+                      "title": "values",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "release",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "kubePrometheusStack",
+              "type": "object"
+            },
+            "lokiStack": {
+              "additionalProperties": false,
+              "properties": {
+                "chart": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "default": "loki-stack",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "repo": {
+                      "default": "https://grafana.github.io/helm-charts",
+                      "title": "repo",
+                      "type": "string"
+                    },
+                    "version": {
+                      "default": "2.10.2",
+                      "title": "version",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "chart",
+                  "type": "object"
+                },
+                "enabled": {
+                  "default": true,
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "release": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "namespace": {
+                      "default": "monitoring-system",
+                      "title": "namespace",
+                      "type": "string"
+                    },
+                    "values": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "loki": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "config": {
+                              "additionalProperties": false,
+                              "description": "Enable retention and configure a default retention period of 31 days",
+                              "properties": {
+                                "compactor": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "retention_enabled": {
+                                      "default": true,
+                                      "title": "retention_enabled",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [],
+                                  "title": "compactor",
+                                  "type": "object"
+                                },
+                                "limits_config": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "retention_period": {
+                                      "default": "72h",
+                                      "title": "retention_period",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [],
+                                  "title": "limits_config",
+                                  "type": "object"
+                                }
+                              },
+                              "required": [],
+                              "title": "config",
+                              "type": "object"
+                            },
+                            "persistence": {
+                              "additionalProperties": false,
+                              "description": "Enable persistence by default",
+                              "properties": {
+                                "enabled": {
+                                  "default": true,
+                                  "title": "enabled",
+                                  "type": "boolean"
+                                },
+                                "size": {
+                                  "default": "10Gi",
+                                  "title": "size",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [],
+                              "title": "persistence",
+                              "type": "object"
+                            }
+                          },
+                          "required": [],
+                          "title": "loki",
+                          "type": "object"
+                        }
+                      },
+                      "required": [],
+                      "title": "values",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "release",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "lokiStack",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "monitoring",
+          "type": "object"
+        },
+        "nodeFeatureDiscovery": {
+          "additionalProperties": false,
+          "description": "Settings for node feature discovery\nhttps://github.com/kubernetes-sigs/node-feature-discovery/tree/master/deployment/helm/node-feature-discovery",
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "node-feature-discovery",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://kubernetes-sigs.github.io/node-feature-discovery/charts",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "0.18.3",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "enabled": {
+              "default": true,
+              "description": "Indicates if node feature discovery should be enabled",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "node-feature-discovery",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": false,
+                  "required": [],
+                  "title": "values",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "nodeFeatureDiscovery",
+          "type": "object"
+        },
+        "nodeProblemDetector": {
+          "additionalProperties": false,
+          "description": "Settings for the node problem detector",
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "node-problem-detector",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://charts.deliveryhero.io",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "2.3.14",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "enabled": {
+              "default": true,
+              "description": "Indicates if the node problem detector should be enabled",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "node-problem-detector",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": false,
+                  "required": [],
+                  "title": "values",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "nodeProblemDetector",
+          "type": "object"
+        },
+        "nvidiaGPUOperator": {
+          "additionalProperties": false,
+          "description": "Settings for the NVIDIA GPU operator",
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "gpu-operator",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://helm.ngc.nvidia.com/nvidia",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "v26.3.1",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "enabled": {
+              "default": true,
+              "description": "Indicates if the NVIDIA GPU operator should be enabled\nNote that because it uses node feature discovery to run only on nodes\nwith an NVIDIA GPU available, the overhead of enabling this on clusters\nthat do not need it now but may need it in the future is low",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "gpu-operator",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "dcgmExporter": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "serviceMonitor": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "enabled": {
+                              "default": true,
+                              "title": "enabled",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [],
+                          "title": "serviceMonitor",
+                          "type": "object"
+                        }
+                      },
+                      "required": [],
+                      "title": "dcgmExporter",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "values",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "nvidiaGPUOperator",
+          "type": "object"
+        },
+        "openstack": {
+          "additionalProperties": false,
+          "description": "Settings for the OpenStack integrations",
+          "properties": {
+            "ccm": {
+              "additionalProperties": false,
+              "description": "Settings for the Cloud Controller Manager (CCM)",
+              "properties": {
+                "chart": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "default": "openstack-cloud-controller-manager",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "repo": {
+                      "default": "https://kubernetes.github.io/cloud-provider-openstack",
+                      "title": "repo",
+                      "type": "string"
+                    },
+                    "version": {
+                      "default": "2.36.0",
+                      "title": "version",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "chart",
+                  "type": "object"
+                },
+                "enabled": {
+                  "default": true,
+                  "description": "Indicates if the OpenStack CCM should be enabled\nBy default, the CCM is enabled if the OpenStack integrations are enabled\nSee https://github.com/kubernetes/cloud-provider-openstack/blob/master/charts/openstack-cloud-controller-manager/values.yaml",
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "values": {
+                  "additionalProperties": false,
+                  "required": [],
+                  "title": "values",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "ccm",
+              "type": "object"
+            },
+            "cloudConfig": {
+              "additionalProperties": false,
+              "description": "cloud-config options for the OpenStack integrations\nThe [Global] section is configured to use the target cloud\nSee https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#config-openstack-cloud-controller-manager\nand https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/cinder-csi-plugin/using-cinder-csi-plugin.md#block-storage",
+              "properties": {
+                "BlockStorage": {
+                  "additionalProperties": false,
+                  "description": "By default, ignore volume AZs for Cinder as most clouds have a single globally-attachable Cinder AZ",
+                  "properties": {
+                    "ignore-volume-az": {
+                      "default": true,
+                      "title": "ignore-volume-az",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [],
+                  "title": "BlockStorage",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "cloudConfig",
+              "type": "object"
+            },
+            "csiCinder": {
+              "additionalProperties": false,
+              "description": "Settings for the Cinder CSI plugin",
+              "properties": {
+                "additionalStorageClasses": {
+                  "description": "Additional storage classes to create for the Cinder CSI\nFor each item, the properties from the default storage class are supported (except enabled and isClusterDefault)",
+                  "items": {
+                    "required": []
+                  },
+                  "title": "additionalStorageClasses",
+                  "type": "array"
+                },
+                "chart": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "default": "openstack-cinder-csi",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "repo": {
+                      "default": "https://kubernetes.github.io/cloud-provider-openstack",
+                      "title": "repo",
+                      "type": "string"
+                    },
+                    "version": {
+                      "default": "2.35.0",
+                      "title": "version",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "chart",
+                  "type": "object"
+                },
+                "defaultStorageClass": {
+                  "additionalProperties": false,
+                  "description": "Definition of the default storage class for Cinder CSI",
+                  "properties": {
+                    "allowVolumeExpansion": {
+                      "default": true,
+                      "description": "Indicates if volume expansion is allowed",
+                      "title": "allowVolumeExpansion",
+                      "type": "boolean"
+                    },
+                    "allowedTopologies": {
+                      "default": "",
+                      "description": "The allowed topologies for the storage class",
+                      "title": "allowedTopologies",
+                      "type": "null"
+                    },
+                    "availabilityZone": {
+                      "default": "nova",
+                      "description": "The Cinder availability zone to use for volumes provisioned by the storage class",
+                      "title": "availabilityZone",
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "default": true,
+                      "description": "Indicates if the storage class should be enabled",
+                      "title": "enabled",
+                      "type": "boolean"
+                    },
+                    "fstype": {
+                      "default": "",
+                      "description": "Filesystem type to use for volumes provisioned with the storage class\nIf not given, the default filesystem type will be used",
+                      "title": "fstype",
+                      "type": "null"
+                    },
+                    "isClusterDefault": {
+                      "default": true,
+                      "description": "Indicates if the Cinder default storage class is the cluster default storage class",
+                      "title": "isClusterDefault",
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "default": "csi-cinder",
+                      "description": "The name of the storage class",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "reclaimPolicy": {
+                      "default": "Delete",
+                      "description": "The reclaim policy for the storage class",
+                      "title": "reclaimPolicy",
+                      "type": "string"
+                    },
+                    "volumeBindingMode": {
+                      "default": "WaitForFirstConsumer",
+                      "description": "Controls when volume binding and dynamic provisioning should occur",
+                      "title": "volumeBindingMode",
+                      "type": "string"
+                    },
+                    "volumeType": {
+                      "default": "",
+                      "description": "The Cinder volume type to use for volumes provisioned by the storage class\nIf not given, the default volume type will be used",
+                      "title": "volumeType",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [],
+                  "title": "defaultStorageClass",
+                  "type": "object"
+                },
+                "enabled": {
+                  "default": true,
+                  "description": "Indicates if the Cinder CSI should be enabled\nBy default, it is enabled if the OpenStack integrations are enabled\nSee https://github.com/kubernetes/cloud-provider-openstack/blob/master/charts/cinder-csi-plugin/values.yaml",
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "values": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "csi": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "plugin": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "controllerPlugin": {
+                              "additionalProperties": false,
+                              "properties": {
+                                "nodeSelector": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "node-role.kubernetes.io/control-plane": {
+                                      "default": "",
+                                      "title": "node-role.kubernetes.io/control-plane",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [],
+                                  "title": "nodeSelector",
+                                  "type": "object"
+                                },
+                                "tolerations": {
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                          "effect": {
+                                            "default": "NoSchedule",
+                                            "title": "effect",
+                                            "type": "string"
+                                          },
+                                          "key": {
+                                            "default": "node-role.kubernetes.io/control-plane",
+                                            "title": "key",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [],
+                                        "type": "object"
+                                      }
+                                    ],
+                                    "required": []
+                                  },
+                                  "title": "tolerations",
+                                  "type": "array"
+                                }
+                              },
+                              "required": [],
+                              "title": "controllerPlugin",
+                              "type": "object"
+                            }
+                          },
+                          "required": [],
+                          "title": "plugin",
+                          "type": "object"
+                        }
+                      },
+                      "required": [],
+                      "title": "csi",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "values",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "csiCinder",
+              "type": "object"
+            },
+            "csiManila": {
+              "additionalProperties": false,
+              "description": "Settings for the Manila CSI plugin",
+              "properties": {
+                "additionalStorageClasses": {
+                  "description": "Additional storage classes to create for the Manila CSI\nFor each item, the properties from the default storage class are supported (except for \"enabled\")",
+                  "items": {
+                    "required": []
+                  },
+                  "title": "additionalStorageClasses",
+                  "type": "array"
+                },
+                "chart": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "default": "openstack-manila-csi",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "repo": {
+                      "default": "https://kubernetes.github.io/cloud-provider-openstack",
+                      "title": "repo",
+                      "type": "string"
+                    },
+                    "version": {
+                      "default": "2.30.0",
+                      "title": "version",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "chart",
+                  "type": "object"
+                },
+                "defaultStorageClass": {
+                  "additionalProperties": false,
+                  "description": "Definition of the default storage class for the Manila CSI",
+                  "properties": {
+                    "allowVolumeExpansion": {
+                      "default": true,
+                      "description": "Indicates if volume expansion is allowed",
+                      "title": "allowVolumeExpansion",
+                      "type": "boolean"
+                    },
+                    "allowedTopologies": {
+                      "default": "",
+                      "description": "The allowed topologies for the storage class",
+                      "title": "allowedTopologies",
+                      "type": "null"
+                    },
+                    "enabled": {
+                      "default": true,
+                      "description": "Indicates if the storage class should be enabled",
+                      "title": "enabled",
+                      "type": "boolean"
+                    },
+                    "isClusterDefault": {
+                      "default": false,
+                      "description": "Indicates if the Manila default storage class is the cluster default storage class",
+                      "title": "isClusterDefault",
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "default": "csi-manila",
+                      "description": "The name of the storage class",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "parameters": {
+                      "additionalProperties": false,
+                      "description": "The parameters for the storage class\nSee https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/manila-csi-plugin/using-manila-csi-plugin.md#controller-service-volume-parameters",
+                      "properties": {
+                        "type": {
+                          "default": "",
+                          "description": "The Manila share type to use\nIf not given and the Ceph CSI plugin is installed, cephfs is used",
+                          "title": "type",
+                          "type": "null"
+                        }
+                      },
+                      "required": [],
+                      "title": "parameters",
+                      "type": "object"
+                    },
+                    "provisioner": {
+                      "default": "",
+                      "description": "The provisioner for the storage class\nIf not given and the Ceph CSI plugin is installed, cephfs.manila.csi.openstack.org is used",
+                      "title": "provisioner",
+                      "type": "null"
+                    },
+                    "reclaimPolicy": {
+                      "default": "Delete",
+                      "description": "The reclaim policy for the storage class",
+                      "title": "reclaimPolicy",
+                      "type": "string"
+                    },
+                    "volumeBindingMode": {
+                      "default": "WaitForFirstConsumer",
+                      "description": "Controls when volume binding and dynamic provisioning should occur",
+                      "title": "volumeBindingMode",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "defaultStorageClass",
+                  "type": "object"
+                },
+                "enabled": {
+                  "default": false,
+                  "description": "Indicates if the Manila CSI should be enabled\nBy default, it is disabled as Manila is not commonly available\nSee https://github.com/kubernetes/cloud-provider-openstack/blob/master/charts/manila-csi-plugin/values.yaml",
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "values": {
+                  "additionalProperties": false,
+                  "required": [],
+                  "title": "values",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "csiManila",
+              "type": "object"
+            },
+            "enabled": {
+              "default": false,
+              "description": "Indicates if the OpenStack integrations should be enabled",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "k8sKeystoneAuth": {
+              "additionalProperties": false,
+              "properties": {
+                "chart": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "default": "k8s-keystone-auth",
+                      "title": "name",
+                      "type": "string"
+                    },
+                    "repo": {
+                      "default": "https://catalyst-cloud.github.io/capi-plugin-helm-charts",
+                      "title": "repo",
+                      "type": "string"
+                    },
+                    "version": {
+                      "default": "1.5.1",
+                      "title": "version",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "chart",
+                  "type": "object"
+                },
+                "enabled": {
+                  "default": false,
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "targetNamespace": {
+                  "default": "kube-system",
+                  "title": "targetNamespace",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "k8sKeystoneAuth",
+              "type": "object"
+            },
+            "targetNamespace": {
+              "default": "openstack-system",
+              "description": "The target namespace for the OpenStack integrations",
+              "title": "targetNamespace",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "openstack",
+          "type": "object"
+        },
+        "reloader": {
+          "additionalProperties": false,
+          "description": "Setting for Reloader used to restart workloads on Secret/ConfigMap changes",
+          "properties": {
+            "chart": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "default": "reloader",
+                  "title": "name",
+                  "type": "string"
+                },
+                "repo": {
+                  "default": "https://stakater.github.io/stakater-charts",
+                  "title": "repo",
+                  "type": "string"
+                },
+                "version": {
+                  "default": "2.2.11",
+                  "title": "version",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "chart",
+              "type": "object"
+            },
+            "enabled": {
+              "default": false,
+              "description": "Indicates if Reloader should be enabled",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "release": {
+              "additionalProperties": false,
+              "properties": {
+                "namespace": {
+                  "default": "openstack-system",
+                  "description": "Deploy to the same namespace as OpenStack services",
+                  "title": "namespace",
+                  "type": "string"
+                },
+                "values": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "reloader": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "watchGlobally": {
+                          "default": false,
+                          "description": "Restrict scope to namespace",
+                          "title": "watchGlobally",
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [],
+                      "title": "reloader",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "values",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "release",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "reloader",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "cluster-addons",
+      "type": "object"
+    },
+    "apiServer": {
+      "additionalProperties": false,
+      "description": "Settings for the Kubernetes API server",
+      "properties": {
+        "admissionConfiguration": {
+          "additionalProperties": true,
+          "default": "",
+          "description": "The configuration for the built-in admission controllers\nThis should be a map of the controller name to the configuration for the controller",
+          "required": [],
+          "title": "admissionConfiguration",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "allowedCIDRs": {
+          "default": [],
+          "description": "Restrict loadbalancer access to select IPs",
+          "required": [],
+          "title": "allowedCIDRs",
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "associateFloatingIP": {
+          "default": "true",
+          "description": "Restrict loadbalancer access to select IPs\nallowedCidrs:\n - 192.168.0.0/16  # needed for cluster to init\n - 10.10.0.0/16  # IPv4 Internal Network\n - 123.123.123.123 # some other IPs\nIndicates whether to associate a floating IP with the API server",
+          "items": {
+            "type": "string"
+          },
+          "required": [],
+          "title": "associateFloatingIP",
+          "type": [
+            "boolean"
+          ]
+        },
+        "enableLoadBalancer": {
+          "default": true,
+          "description": "Indicates whether to deploy a load balancer for the API server",
+          "title": "enableLoadBalancer",
+          "type": "boolean"
+        },
+        "fixedIP": {
+          "default": "",
+          "description": "The specific fixed IP to associate with the API server\nIf enableLoadBalancer is true, this will become the VIP of the load balancer\nIf enableLoadBalancer and associateFloatingIP are both false, this should be\nthe IP of a pre-allocated port to be used as the VIP",
+          "format": "ipv4",
+          "required": [],
+          "title": "fixedIP",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "floatingIP": {
+          "default": "",
+          "description": "The specific floating IP to associate with the API server\nIf not given, a new IP will be allocated if required",
+          "format": "ipv4",
+          "required": [],
+          "title": "floatingIP",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "loadBalancerProvider": {
+          "default": "",
+          "description": "Indicates what loadbalancer provider to use. Default is amphora",
+          "required": [],
+          "title": "loadBalancerProvider",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "logLevel": {
+          "default": 2,
+          "description": "Log level\n0: Errors\n1: Config info and correctable errors (e.g unhealthy node)\n2: System state changes\n3: Extended system state change info\n4: Debug\n5: Trace",
+          "title": "logLevel",
+          "type": "integer"
+        },
+        "port": {
+          "default": 6443,
+          "description": "The port to use for the API server",
+          "title": "port",
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "title": "apiServer",
+      "type": "object"
+    },
+    "authWebhook": {
+      "default": "none",
+      "description": "API server authentication/authorization webhook. Set this to\nintegrate into KubeadmControlPlane and KubeadmConfigTemplate",
+      "enum": [
+        "none",
+        "k8s-keystone-auth",
+        "azimuth-authorization-webhook"
+      ],
+      "required": [],
+      "title": "authWebhook"
+    },
+    "autoscaler": {
+      "additionalProperties": false,
+      "description": "Configuration for the cluster autoscaler",
+      "properties": {
+        "affinity": {
+          "additionalProperties": true,
+          "description": "Affinity rules for pods",
+          "required": [],
+          "title": "affinity"
+        },
+        "extraArgs": {
+          "additionalProperties": true,
+          "description": "Any extra args for the autoscaler",
+          "properties": {
+            "cordon-node-before-terminating": {
+              "default": "true",
+              "description": "Cordon nodes before terminating them so new pods are not scheduled there",
+              "title": "cordon-node-before-terminating",
+              "type": "string"
+            },
+            "expander": {
+              "default": "least-waste,random",
+              "description": "When scaling up, choose the node group that will result in the least idle CPU after",
+              "title": "expander",
+              "type": "string"
+            },
+            "logtostderr": {
+              "default": true,
+              "description": "Make sure logs go to stderr",
+              "title": "logtostderr",
+              "type": "boolean"
+            },
+            "skip-nodes-with-custom-controller-pods": {
+              "default": "false",
+              "description": "Allow pods with custom controllers to be evicted",
+              "title": "skip-nodes-with-custom-controller-pods",
+              "type": "string"
+            },
+            "skip-nodes-with-local-storage": {
+              "default": "false",
+              "description": "Allow pods with emptyDirs to be evicted",
+              "title": "skip-nodes-with-local-storage",
+              "type": "string"
+            },
+            "skip-nodes-with-system-pods": {
+              "default": "true",
+              "description": "Allow pods in kube-system to prevent a node from being deleted",
+              "title": "skip-nodes-with-system-pods",
+              "type": "string"
+            },
+            "stderrthreshold": {
+              "default": "info",
+              "title": "stderrthreshold",
+              "type": "string"
+            },
+            "v": {
+              "default": 4,
+              "description": "Output at a decent log level",
+              "title": "v",
+              "type": "integer"
+            }
+          },
+          "required": [],
+          "title": "extraArgs"
+        },
+        "image": {
+          "additionalProperties": false,
+          "description": "The image to use for the autoscaler component",
+          "properties": {
+            "pullPolicy": {
+              "default": "IfNotPresent",
+              "title": "pullPolicy",
+              "type": "string"
+            },
+            "repository": {
+              "default": "registry.k8s.io/autoscaling/cluster-autoscaler",
+              "title": "repository",
+              "type": "string"
+            },
+            "tag": {
+              "default": "v1.30.4",
+              "title": "tag",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "image",
+          "type": "object"
+        },
+        "imagePullSecrets": {
+          "items": {
+            "properties": {
+              "name": {
+                "required": [],
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [],
+            "type": "object"
+          },
+          "title": "imagePullSecrets",
+          "type": "array"
+        },
+        "nodeSelector": {
+          "additionalProperties": true,
+          "description": "Node selector for pods",
+          "required": [],
+          "title": "nodeSelector"
+        },
+        "podSecurityContext": {
+          "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/podsecuritycontext-v1.json",
+          "additionalProperties": false,
+          "required": []
+        },
+        "resources": {
+          "additionalProperties": true,
+          "description": "Resource requests and limits for pods",
+          "required": [],
+          "title": "resources"
+        },
+        "securityContext": {
+          "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
+          "additionalProperties": false,
+          "required": []
+        },
+        "tolerations": {
+          "description": "Tolerations for pods",
+          "items": {
+            "required": []
+          },
+          "title": "tolerations",
+          "type": "array"
+        },
+        "topologySpreadConstraints": {
+          "description": "Topology spread constraints for pods",
+          "items": {
+            "required": []
+          },
+          "title": "topologySpreadConstraints",
+          "type": "array"
+        }
+      },
+      "required": [],
+      "title": "autoscaler",
+      "type": "object"
+    },
+    "azimuthAuthorizationWebhook": {
+      "additionalProperties": false,
+      "properties": {
+        "additionalAuthorizers": {
+          "items": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "default": "node",
+                    "title": "name",
+                    "type": "string"
+                  },
+                  "type": {
+                    "default": "Node",
+                    "title": "type",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "name"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "default": "rbac",
+                    "title": "name",
+                    "type": "string"
+                  },
+                  "type": {
+                    "default": "RBAC",
+                    "title": "type",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "name"
+                ],
+                "type": "object"
+              }
+            ],
+            "required": []
+          },
+          "title": "additionalAuthorizers",
+          "type": "array"
+        },
+        "extraPreFilters": {
+          "items": {
+            "type": "string"
+          },
+          "title": "extraPreFilters",
+          "type": "array"
+        },
+        "failurePolicy": {
+          "default": "Deny",
+          "title": "failurePolicy",
+          "type": "string"
+        },
+        "filteredNamespaces": {
+          "description": "Should at least include the values provided to .Values.protectedNamespaces in\nhttps://github.com/azimuth-cloud/azimuth-authorization-webhook/blob/main/chart/values.yaml",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "required": []
+          },
+          "title": "filteredNamespaces",
+          "type": "array"
+        },
+        "server": {
+          "default": "",
+          "required": [],
+          "title": "server",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "timeout": {
+          "default": "10s",
+          "title": "timeout",
+          "type": "string"
+        },
+        "tls": {
+          "additionalProperties": false,
+          "properties": {
+            "cert": {
+              "default": "",
+              "required": [],
+              "title": "cert",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "enabled": {
+              "default": true,
+              "title": "enabled",
+              "type": "boolean"
+            }
+          },
+          "required": [],
+          "title": "tls",
+          "type": "object"
+        },
+        "webhookVersion": {
+          "default": "v1",
+          "title": "webhookVersion",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "azimuthAuthorizationWebhook",
+      "type": "object"
+    },
+    "cloudCACert": {
+      "default": "",
+      "description": "The PEM-encoded CA certificate for the specified cloud",
+      "required": [],
+      "title": "cloudCACert",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "cloudCredentialsSecretName": {
+      "default": "",
+      "description": "The name of an existing secret containing a clouds.yaml and optional cacert",
+      "required": [],
+      "title": "cloudCredentialsSecretName",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "cloudName": {
+      "default": "openstack",
+      "description": "The name of the cloud to use from the specified clouds.yaml",
+      "title": "cloudName",
+      "type": "string"
+    },
+    "clouds": {
+      "default": "",
+      "description": "OR\nContent for the clouds.yaml file\nHaving this as a top-level item allows a clouds.yaml file from OpenStack to be used as a values file",
+      "required": [],
+      "title": "clouds",
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "clusterAnnotations": {
+      "additionalProperties": false,
+      "description": "Any extra annotations to add to the cluster",
+      "patternProperties": {
+        ".*": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "clusterAnnotations",
+      "type": "object"
+    },
+    "clusterNetworking": {
+      "additionalProperties": false,
+      "description": "Settings for the OpenStack networking for the cluster",
+      "properties": {
+        "allowAllInClusterTraffic": {
+          "default": true,
+          "description": "Indicates if the managed security groups should allow all in-cluster traffic\nThe default CNI installed by the addons is Cilium, so this is true by default",
+          "title": "allowAllInClusterTraffic",
+          "type": "boolean"
+        },
+        "disableExternalNetwork": {
+          "default": false,
+          "description": "Custom nameservers to use for the hosts\nDeprecated; use `clusterNetworking.internalNetwork.dnsNameservers` instead.\ndnsNameservers: []\nIndicates whether or not to attempt to connect the cluster to an external\nnetwork.",
+          "title": "disableExternalNetwork",
+          "type": "boolean"
+        },
+        "controlPlaneNodesSecurityGroupRules": {
+          "default": [],
+          "description": "A list of security groups to apply to worker nodes when OVN is the apiserver loadbalancer provider",
+          "title": "controlPlaneNodesSecurityGroupRules",
+          "type": "array"
+        },
+        "externalNetworkId": {
+          "default": "",
+          "description": "The ID of the external network to use\nIf not given, the external network will be detected",
+          "required": [],
+          "title": "externalNetworkId",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "internalNetwork": {
+          "additionalProperties": false,
+          "description": "Details of the internal network to use",
+          "properties": {
+            "dnsNameservers": {
+              "default": "",
+              "description": "List of nameserver IPs to use when creating a cluster network.\nThis is only used if neither of networkFilter and subnetFilter are given",
+              "items": {
+                "format": "ipv4",
+                "required": []
+              },
+              "required": [],
+              "title": "dnsNameservers",
+              "type": [
+                "array",
+                "null"
+              ]
+            },
+            "networkFilter": {
+              "default": "",
+              "description": "Filter to find an existing network for the cluster internal network\nsee Cluster API documentation for details",
+              "properties": {
+                "id": {
+                  "required": [],
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "required": [],
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [],
+              "title": "networkFilter"
+            },
+            "nodeCidr": {
+              "default": "192.168.3.0/24",
+              "description": "id: e63ca1a0-f69d-4fbf-b306-31089s1j38d8\nname: tenant-internal-subnet\nThe CIDR to use if creating a cluster network\nThis is only used if neither of networkFilter and subnetFilter are given",
+              "title": "nodeCidr",
+              "type": "string"
+            },
+            "subnetFilter": {
+              "default": "",
+              "description": "id: e63ca1a0-f69d-4fbf-b306-310857b1afe5\nname: tenant-internal-net\nFilter to find an existing subnet for the cluster internal network\nSee Cluster API documentation for details",
+              "properties": {
+                "id": {
+                  "required": [],
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "required": [],
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [],
+              "title": "subnetFilter"
+            }
+          },
+          "required": [],
+          "title": "internalNetwork",
+          "type": "object"
+        },
+        "manageSecurityGroups": {
+          "default": true,
+          "description": "Indicates if security groups should be managed by the cluster",
+          "title": "manageSecurityGroups",
+          "type": "boolean"
+        },
+        "workerNodeSecurityGroupRules": {
+          "default": [],
+          "description": "A list of security groups to apply to worker nodes when OVN is the apiserver loadbalancer provider",
+          "title": "workerNodeSecurityGroupRules",
+          "type": "array"
+        }
+      },
+      "required": [],
+      "title": "clusterNetworking",
+      "type": "object"
+    },
+    "controlPlane": {
+      "additionalProperties": false,
+      "description": "Settings for the control plane",
+      "properties": {
+        "additionalBlockDevices": {
+          "additionalProperties": true,
+          "description": "my.company.org/label: value\nAdditional block devices for control plane machines",
+          "patternProperties": {
+            ".*": {
+              "properties": {
+                "availabilityZone": {
+                  "required": [],
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "size": {
+                  "type": "integer"
+                },
+                "type": {
+                  "enum": [
+                    "Volume",
+                    "Local"
+                  ],
+                  "required": []
+                },
+                "volumeType": {
+                  "required": [],
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [],
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "additionalBlockDevices",
+          "type": "object"
+        },
+        "failureDomains": {
+          "default": "",
+          "description": "The failure domains to use for control plane nodes\nIf given, should be a list of availability zones\nOnly used when omitFailureDomain = false",
+          "items": {
+            "type": "string"
+          },
+          "required": [],
+          "title": "failureDomains",
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "healthCheck": {
+          "additionalProperties": false,
+          "description": "The machine health check for auto-healing of the control plane\nSee https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking",
+          "properties": {
+            "enabled": {
+              "default": true,
+              "description": "Indicates if the machine health check should be enabled",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "spec": {
+              "additionalProperties": true,
+              "description": "The spec for the health check",
+              "properties": {
+                "maxUnhealthy": {
+                  "default": 1,
+                  "description": "By default, don't remediate control plane nodes when more than one is unhealthy",
+                  "title": "maxUnhealthy",
+                  "type": "integer"
+                },
+                "nodeStartupTimeout": {
+                  "default": "30m0s",
+                  "description": "If a node takes longer than 30 mins to startup, remediate it",
+                  "title": "nodeStartupTimeout",
+                  "type": "string"
+                },
+                "unhealthyConditions": {
+                  "description": "By default, consider a control plane node that has not been Ready\nfor more than 5 mins unhealthy",
+                  "items": {
+                    "additionalProperties": true,
+                    "required": [],
+                    "type": "object"
+                  },
+                  "title": "unhealthyConditions",
+                  "type": "array"
+                }
+              },
+              "required": [],
+              "title": "spec"
+            }
+          },
+          "required": [],
+          "title": "healthCheck",
+          "type": "object"
+        },
+        "kubeadmConfigSpec": {
+          "additionalProperties": true,
+          "description": "The kubeadm config specification for the control plane\nBy default, this uses a simple configuration that enables the external cloud provider",
+          "properties": {
+            "clusterConfiguration": {
+              "additionalProperties": false,
+              "description": "As well as enabling an external cloud provider, we set the bind addresses for the\ncontroller-manager, scheduler and kube-proxy to 0.0.0.0 so that Prometheus can reach\nthem to collect metrics",
+              "properties": {
+                "controllerManager": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "extraArgs": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bind-address": {
+                          "default": "0.0.0.0",
+                          "title": "bind-address",
+                          "type": "string"
+                        },
+                        "cloud-provider": {
+                          "default": "external",
+                          "title": "cloud-provider",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "extraArgs",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "controllerManager",
+                  "type": "object"
+                },
+                "scheduler": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "extraArgs": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "bind-address": {
+                          "default": "0.0.0.0",
+                          "title": "bind-address",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "extraArgs",
+                      "type": "object"
+                    }
+                  },
+                  "required": [],
+                  "title": "scheduler",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "clusterConfiguration",
+              "type": "object"
+            },
+            "initConfiguration": {
+              "additionalProperties": false,
+              "properties": {
+                "nodeRegistration": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "kubeletExtraArgs": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "cloud-provider": {
+                          "default": "external",
+                          "title": "cloud-provider",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "kubeletExtraArgs",
+                      "type": "object"
+                    },
+                    "name": {
+                      "default": "{{ local_hostname }}",
+                      "title": "name",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "nodeRegistration",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "initConfiguration",
+              "type": "object"
+            },
+            "joinConfiguration": {
+              "additionalProperties": false,
+              "properties": {
+                "nodeRegistration": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "kubeletExtraArgs": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "cloud-provider": {
+                          "default": "external",
+                          "title": "cloud-provider",
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "title": "kubeletExtraArgs",
+                      "type": "object"
+                    },
+                    "name": {
+                      "default": "{{ local_hostname }}",
+                      "title": "name",
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "title": "nodeRegistration",
+                  "type": "object"
+                }
+              },
+              "required": [],
+              "title": "joinConfiguration",
+              "type": "object"
+            },
+            "kubeProxyConfiguration": {
+              "additionalProperties": false,
+              "properties": {
+                "metricsBindAddress": {
+                  "default": "0.0.0.0:10249",
+                  "title": "metricsBindAddress",
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "title": "kubeProxyConfiguration",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "kubeadmConfigSpec",
+          "type": "object"
+        },
+        "kubernetesVersion": {
+          "default": "",
+          "description": "The kubernetes version for the control plane",
+          "pattern": "1.[0-9][0-9].[0-9]+",
+          "required": [],
+          "title": "kubernetesVersion",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "machineConfigDrive": {
+          "default": false,
+          "description": "# The key is the name for the block device in the context of the machine\n# It is also used to tag the block device, so that the volume can be identified in instance metadata\nscratch:\n  # The size of the block device\n  size: 20\n  # The type of the block device\n  # If set to \"Volume\", which is the default, then a Cinder volume is used to back the block device\n  # If set to \"Local\", local ephemeral storage is used to back the block device\n  # In both cases, the lifecycle of the device is the same as the machine\n  type: Volume\n  # The volume type to use\n  # If not specified, the default volume type is used\n  volumeType:\n  # The volume availability zone to use\n  # If not specified, the machine availability zone is used\n  availabilityZone:\nIndicates whether control plane machines should use config drive or not",
+          "title": "machineConfigDrive",
+          "type": "boolean"
+        },
+        "machineCount": {
+          "default": 3,
+          "description": "The number of control plane machines to deploy\nFor high-availability, this should be greater than 1\nFor etcd quorum, it should be odd - usually 3, or 5 for very large clusters",
+          "title": "machineCount",
+          "type": "integer"
+        },
+        "machineFlavor": {
+          "default": "",
+          "description": "The flavor to use for control plane machines",
+          "required": [],
+          "title": "machineFlavor",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "machineImage": {
+          "default": "",
+          "description": "The image to use for control plane",
+          "required": [],
+          "title": "machineImage",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "machineImageId": {
+          "default": "",
+          "description": "The ID of the image to use for the control plane",
+          "required": [],
+          "title": "machineImageId",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "machineMetadata": {
+          "additionalProperties": true,
+          "description": "Specific metadata for control plane nodes",
+          "required": [],
+          "title": "machineMetadata"
+        },
+        "machineNetworking": {
+          "additionalProperties": false,
+          "description": "The ports for control plane nodes\nIf no ports are given, the cluster internal network is used\nSee https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/master/docs/book/src/clusteropenstack/configuration.md#network-filters",
+          "properties": {
+            "ports": {
+              "additionalProperties": true,
+              "default": "",
+              "required": [],
+              "title": "ports",
+              "type": [
+                "object",
+                "null"
+              ]
+            }
+          },
+          "required": [],
+          "title": "machineNetworking",
+          "type": "object"
+        },
+        "machineRootVolume": {
+          "additionalProperties": false,
+          "description": "The root volume spec for control plane machines",
+          "properties": {
+            "availabilityZone": {
+              "default": "",
+              "description": "The volume availability zone to use\nIf not specified, the machine availability zone is used",
+              "required": [],
+              "title": "availabilityZone",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "diskSize": {
+              "default": "",
+              "description": "The size of the disk to use\nIf not given, the ephemeral root disk from the flavor is used",
+              "minimum": 20,
+              "required": [],
+              "title": "diskSize",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "volumeType": {
+              "default": "",
+              "description": "The volume type to use\nIf not specified, the default volume type is used",
+              "required": [],
+              "title": "volumeType",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [],
+          "title": "machineRootVolume",
+          "type": "object"
+        },
+        "nodeDeletionTimeout": {
+          "default": "5m0s",
+          "description": "The time to wait for the node resource to be deleted in Kubernetes when a\nmachine is marked for deletion",
+          "title": "nodeDeletionTimeout",
+          "type": "string"
+        },
+        "nodeDrainTimeout": {
+          "default": "5m0s",
+          "description": "The time to wait for a node to finish draining before it can be removed",
+          "title": "nodeDrainTimeout",
+          "type": "string"
+        },
+        "nodeLabels": {
+          "default": "",
+          "description": "Labels to apply to the node objects in Kubernetes that correspond to control plane machines",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "nodeLabels",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "nodeVolumeDetachTimeout": {
+          "default": "5m0s",
+          "description": "The time to wait for a node to detach all volumes before it can be removed",
+          "title": "nodeVolumeDetachTimeout",
+          "type": "string"
+        },
+        "omitFailureDomain": {
+          "default": true,
+          "description": "Indicates whether the failure domain should be omitted from control plane nodes",
+          "title": "omitFailureDomain",
+          "type": "boolean"
+        },
+        "remediationStrategy": {
+          "additionalProperties": false,
+          "description": "The remediation strategy for the control plane nodes\nWe set these so that we don't keep remediating an unhealthy control plane forever",
+          "properties": {
+            "maxRetry": {
+              "default": 3,
+              "description": "The maximum number of times that a remediation will be retried",
+              "title": "maxRetry",
+              "type": "integer"
+            },
+            "minHealthyPeriod": {
+              "default": "1h",
+              "description": "The length of time that a node must be healthy before any future problems are\nconsidered unrelated to the previous ones (i.e. the retry count is reset)",
+              "title": "minHealthyPeriod",
+              "type": "string"
+            },
+            "retryPeriod": {
+              "default": "20m",
+              "description": "The amount of time that a node created as a remediation has to become healthy\nbefore the remediation is retried",
+              "title": "retryPeriod",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "remediationStrategy",
+          "type": "object"
+        },
+        "rolloutStrategy": {
+          "$ref": "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/controlplane.cluster.x-k8s.io/kubeadmcontrolplane_v1beta1.json#/properties/spec/properties/rolloutStrategy",
+          "additionalProperties": false,
+          "required": []
+        },
+        "serverGroupId": {
+          "default": "",
+          "description": "The ID of the server group to use for control plane machines",
+          "required": [],
+          "title": "serverGroupId",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [],
+      "title": "controlPlane",
+      "type": "object"
+    },
+    "etcd": {
+      "additionalProperties": false,
+      "description": "Settings for etcd",
+      "properties": {
+        "blockDevice": {
+          "default": "",
+          "description": "The block device configuration for etcd\nIf not specified, the root device is used",
+          "properties": {
+            "availabilityZone": {
+              "required": [],
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "size": {
+              "type": "integer"
+            },
+            "type": {
+              "enum": [
+                "Volume",
+                "Local"
+              ],
+              "required": []
+            },
+            "volumeType": {
+              "required": [],
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [],
+          "title": "blockDevice",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "dataDir": {
+          "default": "/var/lib/etcd",
+          "description": "The data directory to use for etcd\nWhen a block device is specified, it is mounted at the parent directory, e.g. /var/lib/etcd\nThis is to avoid etcd complaining about the lost+found directory",
+          "title": "dataDir",
+          "type": "string"
+        },
+        "encryption": {
+          "additionalProperties": false,
+          "description": "At-rest encryption settings",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "provider": {
+              "default": "secretbox",
+              "description": "Encryption provider, see https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#providers",
+              "title": "provider",
+              "type": "string"
+            },
+            "resources": {
+              "description": "K8s resources to encrypt",
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  }
+                ],
+                "required": []
+              },
+              "title": "resources",
+              "type": "array"
+            }
+          },
+          "required": [],
+          "title": "encryption",
+          "type": "object"
+        },
+        "extraArgs": {
+          "additionalProperties": true,
+          "description": "Any extra command line arguments to pass to etcd",
+          "properties": {
+            "election-timeout": {
+              "default": "5000",
+              "title": "election-timeout",
+              "type": "string"
+            },
+            "heartbeat-interval": {
+              "default": "500",
+              "description": "Set timeouts so that etcd tolerates 'slowness' (network + disks) better\nThis is at the expense of taking longer to detect a leader failure\nhttps://etcd.io/docs/v3.5/tuning/#time-parameters",
+              "title": "heartbeat-interval",
+              "type": "string"
+            },
+            "listen-metrics-urls": {
+              "default": "http://0.0.0.0:2381",
+              "description": "Listen for metrics on 0.0.0.0 so Prometheus can collect them",
+              "title": "listen-metrics-urls",
+              "type": "string"
+            },
+            "quota-backend-bytes": {
+              "default": "4294967296",
+              "description": "Set a slightly larger space quota than the default (default is 2GB)",
+              "title": "quota-backend-bytes",
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "extraArgs"
+        }
+      },
+      "required": [],
+      "title": "etcd",
+      "type": "object"
+    },
+    "global": {
+      "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",
+      "required": [],
+      "title": "global",
+      "type": "object"
+    },
+    "kubeNetwork": {
+      "additionalProperties": false,
+      "description": "Values for the Kubernetes cluster network",
+      "properties": {
+        "pods": {
+          "additionalProperties": false,
+          "description": "By default, use the private network range 172.16.0.0/12 for the cluster network\nWe split it into two equally-sized blocks for pods and services\nThis gives ~500,000 addresses in each block",
+          "properties": {
+            "cidrBlocks": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  }
+                ],
+                "required": []
+              },
+              "title": "cidrBlocks",
+              "type": "array"
+            }
+          },
+          "required": [],
+          "title": "pods",
+          "type": "object"
+        },
+        "serviceDomain": {
+          "default": "cluster.local",
+          "title": "serviceDomain",
+          "type": "string"
+        },
+        "services": {
+          "additionalProperties": false,
+          "properties": {
+            "cidrBlocks": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  }
+                ],
+                "required": []
+              },
+              "title": "cidrBlocks",
+              "type": "array"
+            }
+          },
+          "required": [],
+          "title": "services",
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "kubeNetwork",
+      "type": "object"
+    },
+    "kubernetesVersion": {
+      "default": "",
+      "description": "The Kubernetes version of the cluster\nThis should match the version of kubelet and kubeadm in the image",
+      "pattern": "1.[0-9][0-9].[0-9]+",
+      "title": "kubernetesVersion",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "machineImage": {
+      "default": "",
+      "description": "The name of the image to use for cluster machines",
+      "required": [],
+      "title": "machineImage",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "machineImageId": {
+      "default": "",
+      "description": "OR\nThe ID of the image to use for cluster machines",
+      "required": [],
+      "title": "machineImageId",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "machineMetadata": {
+      "additionalProperties": true,
+      "description": "Global metadata items to add to each machine",
+      "required": [],
+      "title": "machineMetadata"
+    },
+    "machineSSHKeyName": {
+      "default": "",
+      "description": "The name of the SSH key to inject into cluster machines",
+      "required": [],
+      "title": "machineSSHKeyName",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "nodeGroupDefaults": {
+      "additionalProperties": false,
+      "description": "Defaults for node groups\nEach of these can be overridden in the specification for an individual node group",
+      "properties": {
+        "additionalBlockDevices": {
+          "additionalProperties": true,
+          "description": "my.company.org/label: value\nAdditional block devices for node groups machines\nOptions are the same as for controlPlane.additionalBlockDevices above",
+          "patternProperties": {
+            ".*": {
+              "properties": {
+                "availabilityZone": {
+                  "required": [],
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "size": {
+                  "type": "integer"
+                },
+                "type": {
+                  "enum": [
+                    "Volume",
+                    "Local"
+                  ],
+                  "required": []
+                },
+                "volumeType": {
+                  "required": [],
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [],
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "additionalBlockDevices",
+          "type": "object"
+        },
+        "autoscale": {
+          "default": false,
+          "description": "Indicates if the node group should be autoscaled",
+          "title": "autoscale",
+          "type": "boolean"
+        },
+        "failureDomain": {
+          "default": "",
+          "description": "The failure domain for the node group",
+          "required": [],
+          "title": "failureDomain",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "healthCheck": {
+          "additionalProperties": false,
+          "description": "The default machine health check for worker nodes\nSee https://cluster-api.sigs.k8s.io/tasks/healthcheck.html\nNote that maxUnhealthy or unhealthRange are evaluated per node group",
+          "properties": {
+            "enabled": {
+              "default": true,
+              "description": "Indicates if the machine health check should be enabled",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "spec": {
+              "additionalProperties": true,
+              "description": "The spec for the health check",
+              "properties": {
+                "maxUnhealthy": {
+                  "default": "100%",
+                  "description": "We have a control place feature gate enabled which blocks all worker node remediation if\ncontrol plane is unhealthy, so should be safe to reset worker remediation threshold to\n100% without the risk of runaway remediations.",
+                  "required": [],
+                  "title": "maxUnhealthy",
+                  "type": [
+                    "string",
+                    "integer"
+                  ]
+                },
+                "nodeStartupTimeout": {
+                  "default": "30m0s",
+                  "description": "If a node takes longer than 30 mins to startup, remediate it",
+                  "title": "nodeStartupTimeout",
+                  "type": "string"
+                },
+                "unhealthyConditions": {
+                  "description": "By default, consider a worker node that has not been Ready for\nmore than 5 mins unhealthy",
+                  "items": {
+                    "additionalProperties": true,
+                    "required": [],
+                    "type": "object"
+                  },
+                  "title": "unhealthyConditions",
+                  "type": "array"
+                }
+              },
+              "required": [],
+              "title": "spec"
+            }
+          },
+          "required": [],
+          "title": "healthCheck",
+          "type": "object"
+        },
+        "kubeadmConfigSpec": {
+          "$ref": "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/bootstrap.cluster.x-k8s.io/kubeadmconfigtemplate_v1beta1.json#/properties/spec/properties/template/properties/spec",
+          "additionalProperties": false,
+          "required": []
+        },
+        "kubernetesVersion": {
+          "default": "",
+          "description": "Kubernetes version for nodeGroup machines",
+          "pattern": "1.[0-9][0-9].[0-9]+",
+          "required": [],
+          "title": "kubernetesVersion",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "machineConfigDrive": {
+          "default": false,
+          "description": "Indicates whether control plane machines should use config drive or not",
+          "title": "machineConfigDrive",
+          "type": "boolean"
+        },
+        "machineFlavor": {
+          "default": "",
+          "description": "The flavor to use for machines in the node group",
+          "required": [],
+          "title": "machineFlavor",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "machineImage": {
+          "default": "",
+          "description": "Default image id for nodeGroup hosts",
+          "required": [],
+          "title": "machineImage",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "machineImageId": {
+          "default": "",
+          "description": "The ID of the image to use for nodeGroup machines",
+          "required": [],
+          "title": "machineImageId",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "machineMetadata": {
+          "additionalProperties": true,
+          "description": "Specific metadata for worker nodes\nCan also be specified for each node group",
+          "required": [],
+          "title": "machineMetadata"
+        },
+        "machineNetworking": {
+          "additionalProperties": false,
+          "description": "The default networks and ports for worker nodes\nIf neither networks or ports are given, the cluster internal network is used\nThe default ports for worker nodes\nIf no ports are given, the cluster internal network is used\nSee https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/master/docs/book/src/clusteropenstack/configuration.md#network-filters",
+          "properties": {
+            "ports": {
+              "additionalProperties": true,
+              "default": "",
+              "required": [],
+              "title": "ports",
+              "type": [
+                "object",
+                "null"
+              ]
+            }
+          },
+          "required": [],
+          "title": "machineNetworking",
+          "type": "object"
+        },
+        "machineRootVolume": {
+          "additionalProperties": false,
+          "description": "The root volume spec for machines in the node group",
+          "properties": {
+            "availabilityZone": {
+              "default": "",
+              "description": "The volume availability zone to use\nIf not specified, the machine availability zone is used",
+              "required": [],
+              "title": "availabilityZone",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "diskSize": {
+              "default": "",
+              "description": "The size of the disk to use\nIf not given, the ephemeral root disk from the flavor is used",
+              "minimum": 20,
+              "required": [],
+              "title": "diskSize",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "volumeType": {
+              "default": "",
+              "description": "The volume type to use\nIf not specified, the default volume type is used",
+              "required": [],
+              "title": "volumeType",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [],
+          "title": "machineRootVolume",
+          "type": "object"
+        },
+        "nodeDeletionTimeout": {
+          "default": "5m0s",
+          "description": "The time to wait for the node resource to be deleted in Kubernetes when a\nmachine is marked for deletion",
+          "title": "nodeDeletionTimeout",
+          "type": "string"
+        },
+        "nodeDrainTimeout": {
+          "default": "5m0s",
+          "description": "The time to wait for a node to finish draining before it can be removed",
+          "title": "nodeDrainTimeout",
+          "type": "string"
+        },
+        "nodeLabels": {
+          "default": "",
+          "description": "Labels to apply to the node objects in Kubernetes that correspond to machines in the node group\nBy default, nodes get the label \"capi.stackhpc.com/node-group=\u003cnode group name\u003e\"",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "required": [],
+          "title": "nodeLabels",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "nodeVolumeDetachTimeout": {
+          "default": "5m0s",
+          "description": "The time to wait for a node to detach all volumes before it can be removed",
+          "title": "nodeVolumeDetachTimeout",
+          "type": "string"
+        },
+        "rolloutStrategy": {
+          "$ref": "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cluster.x-k8s.io/machinedeployment_v1beta1.json#/properties/spec/properties/strategy",
+          "additionalProperties": false,
+          "required": []
+        },
+        "serverGroupId": {
+          "default": "",
+          "description": "The ID of the server group to use for machines in the node group",
+          "required": [],
+          "title": "serverGroupId",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [],
+      "title": "nodeGroupDefaults",
+      "type": "object"
+    },
+    "nodeGroups": {
+      "description": "The worker node groups for the cluster\nSee nodeGroupDefaults schema for details",
+      "items": {
+        "additionalProperties": true,
+        "required": [],
+        "type": "object"
+      },
+      "title": "nodeGroups",
+      "type": "array"
+    },
+    "oidc": {
+      "additionalProperties": false,
+      "description": "Settings for connecting to the cluster using OpenID Connect (OIDC)\nIf issuerUrl is not specified, OIDC authentication is not enabled",
+      "properties": {
+        "clientId": {
+          "default": "",
+          "description": "The client ID that tokens are issued for",
+          "required": [],
+          "title": "clientId",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "groupsClaim": {
+          "default": "groups",
+          "description": "The claim to extract the user's groups from",
+          "title": "groupsClaim",
+          "type": "string"
+        },
+        "groupsPrefix": {
+          "default": "oidc:",
+          "description": "The prefix to append to groups from OIDC, similar to usernamePrefix",
+          "title": "groupsPrefix",
+          "type": "string"
+        },
+        "issuerUrl": {
+          "default": "",
+          "description": "The URL of the OIDC provider (i.e. the discovery URL with the well-known component removed)\ne.g. if the discovery URL is https://auth.example.com/.well-known/openid-configuration, the\n     given value should be https://auth.example.com",
+          "pattern": "https?://",
+          "required": [],
+          "title": "issuerUrl",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "signingAlgs": {
+          "default": "RS256",
+          "description": "The signing algorithms that are accepted",
+          "title": "signingAlgs",
+          "type": "string"
+        },
+        "usernameClaim": {
+          "default": "sub",
+          "description": "The claim to extract the username from",
+          "title": "usernameClaim",
+          "type": "string"
+        },
+        "usernamePrefix": {
+          "default": "oidc:",
+          "description": "The prefix to append to usernames from OIDC\nUsed to prevent collisions with existing names, e.g. service accounts\nFor example, if the claim specified in usernameClaim contains jbloggs and the prefix is set\nto oidc:, then in Kubernetes the user can be referred to as oidc:jbloggs",
+          "title": "usernamePrefix",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "oidc",
+      "type": "object"
+    },
+    "osDistro": {
+      "default": "ubuntu",
+      "description": "Set osDistro used. ubuntu, flatcar, etc.",
+      "title": "osDistro",
+      "type": "string"
+    },
+    "projectPrefix": {
+      "default": "capi.stackhpc.com",
+      "description": "The prefix used for project labels and annotations",
+      "title": "projectPrefix",
+      "type": "string"
+    },
+    "registryMirrors": {
+      "additionalProperties": true,
+      "description": "Settings for registry mirrors\nWhen a mirror is set, it will be tried for images but will fall back to the\nupstream registry if the image pull fails\nBy default, use images mirrored to quay.io when possible",
+      "properties": {
+        "docker.io": {
+          "description": "docker.io:\n  upstream: https://registry-1.docker.io\n  mirrors:\n    - url: https://registry.my.domain/v2/dockerhub-public\n      capabilities: [\"pull\", \"resolve\"]",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              }
+            ],
+            "required": []
+          },
+          "title": "docker.io",
+          "type": "array"
+        },
+        "ghcr.io": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              }
+            ],
+            "required": []
+          },
+          "title": "ghcr.io",
+          "type": "array"
+        },
+        "nvcr.io": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              }
+            ],
+            "required": []
+          },
+          "title": "nvcr.io",
+          "type": "array"
+        },
+        "quay.io": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              }
+            ],
+            "required": []
+          },
+          "title": "quay.io",
+          "type": "array"
+        },
+        "registry.k8s.io": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              }
+            ],
+            "required": []
+          },
+          "title": "registry.k8s.io",
+          "type": "array"
+        }
+      },
+      "required": [],
+      "title": "registryMirrors"
+    },
+    "trustedCAs": {
+      "additionalProperties": true,
+      "description": "A map of trusted CAs to add to the system trust on cluster nodes",
+      "required": [],
+      "title": "trustedCAs"
+    }
+  },
+  "required": [],
+  "type": "object"
+}

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -1,75 +1,160 @@
 ---
+# yaml-language-server: $schema=values.schema.json
 
 # The name of an existing secret containing a clouds.yaml and optional cacert
+# @schema
+# type: [string, null]
+# @schema
 cloudCredentialsSecretName:
 # OR
 # Content for the clouds.yaml file
 # Having this as a top-level item allows a clouds.yaml file from OpenStack to be used as a values file
+# @schema
+# type: [object,null]
+# @schema
 clouds:
+
 # The PEM-encoded CA certificate for the specified cloud
+# @schema
+# type: [string, null]
+# @schema
 cloudCACert:
 
+# @schema
+# type: string
+# @schema
 # The name of the cloud to use from the specified clouds.yaml
 cloudName: openstack
 
 # The Kubernetes version of the cluster
 # This should match the version of kubelet and kubeadm in the image
+# @schema
+# type: string
+# pattern: 1.[0-9][0-9].[0-9]+
+# @schema
 kubernetesVersion:
 
 # The name of the image to use for cluster machines
+# @schema
+# type: [string, null]
+# @schema
 machineImage:
 # OR
 # The ID of the image to use for cluster machines
+# @schema
+# type: [string, null]
+# @schema
 machineImageId:
 
 # The name of the SSH key to inject into cluster machines
+# @schema
+# type: [string, null]
+# @schema
 machineSSHKeyName:
 
 # Global metadata items to add to each machine
+# @schema
+# additionalProperties: true
+# @schema
 machineMetadata: {}
 
+# @schema
+# type: string
+# @schema
 # The prefix used for project labels and annotations
 projectPrefix: capi.stackhpc.com
 
 # Any extra annotations to add to the cluster
+# @schema
+# type: object
+# patternProperties:
+#   ".*":
+#     type: string
+# @schema
 clusterAnnotations: {}
 
+# @schema
+# type: object
+# @schema
 # Settings for connecting to the cluster using OpenID Connect (OIDC)
-# If not specified, OIDC authentication is not enabled
+# If issuerUrl is not specified, OIDC authentication is not enabled
 oidc:
   # The URL of the OIDC provider (i.e. the discovery URL with the well-known component removed)
   # e.g. if the discovery URL is https://auth.example.com/.well-known/openid-configuration, the
   #      given value should be https://auth.example.com
+  # @schema
+  # type: [string, null]
+  # pattern: https?://
+  # @schema
   issuerUrl:
   # The client ID that tokens are issued for
+  # @schema
+  # type: [string, null]
+  # @schema
   clientId:
+  # @schema
+  # type: string
+  # @schema
   # The claim to extract the username from
   usernameClaim: sub
+  # @schema
+  # type: string
+  # @schema
   # The prefix to append to usernames from OIDC
   # Used to prevent collisions with existing names, e.g. service accounts
   # For example, if the claim specified in usernameClaim contains jbloggs and the prefix is set
   # to oidc:, then in Kubernetes the user can be referred to as oidc:jbloggs
   usernamePrefix: "oidc:"
+  # @schema
+  # type: string
+  # @schema
   # The claim to extract the user's groups from
   groupsClaim: groups
+  # @schema
+  # type: string
+  # @schema
   # The prefix to append to groups from OIDC, similar to usernamePrefix
   groupsPrefix: "oidc:"
+  # @schema
+  # type: string
+  # @schema
   # The signing algorithms that are accepted
   signingAlgs: RS256
 
+# @schema
+# type: object
+# @schema
 # Values for the Kubernetes cluster network
 kubeNetwork:
+  # @schema
+  # type: object
+  # @schema
   # By default, use the private network range 172.16.0.0/12 for the cluster network
   # We split it into two equally-sized blocks for pods and services
   # This gives ~500,000 addresses in each block
   pods:
+    # @schema
+    # type: array
+    # @schema
     cidrBlocks:
       - 172.16.0.0/13
+  # @schema
+  # type: object
+  # @schema
   services:
+    # @schema
+    # type: array
+    # @schema
     cidrBlocks:
       - 172.24.0.0/13
+  # @schema
+  # type: string
+  # @schema
   serviceDomain: cluster.local
 
+# @schema
+# type: object
+# @schema
 # Settings for the OpenStack networking for the cluster
 clusterNetworking:
   # Custom nameservers to use for the hosts
@@ -77,9 +162,18 @@ clusterNetworking:
   # dnsNameservers: []
   # Indicates whether or not to attempt to connect the cluster to an external
   # network.
+  # @schema
+  # type: boolean
+  # @schema
   disableExternalNetwork: false
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates if security groups should be managed by the cluster
   manageSecurityGroups: true
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates if the managed security groups should allow all in-cluster traffic
   # The default CNI installed by the addons is Cilium, so this is true by default
   allowAllInClusterTraffic: true
@@ -89,17 +183,40 @@ clusterNetworking:
   controlPlaneNodesSecurityGroupRules: []
   # The ID of the external network to use
   # If not given, the external network will be detected
+  # @schema
+  # type: [string, null]
+  # @schema
   externalNetworkId:
+  # @schema
+  # type: object
+  # @schema
   # Details of the internal network to use
   internalNetwork:
     # Filter to find an existing network for the cluster internal network
     # see Cluster API documentation for details
+    # @schema
+    # properties:
+    #   id:
+    #     type: [string, null]
+    #   name:
+    #     type: [string, null]
+    # @schema
     networkFilter:
       # id: e63ca1a0-f69d-4fbf-b306-310857b1afe5
       # name: tenant-internal-net
     # Filter to find an existing subnet for the cluster internal network
     # See Cluster API documentation for details
+    # @schema
+    # properties:
+    #   id:
+    #     type: [string, null]
+    #   name:
+    #     type: [string, null]
+    # @schema
     subnetFilter:
+    # @schema
+    # type: string
+    # @schema
       # id: e63ca1a0-f69d-4fbf-b306-31089s1j38d8
       # name: tenant-internal-subnet
     # The CIDR to use if creating a cluster network
@@ -107,13 +224,24 @@ clusterNetworking:
     nodeCidr: 192.168.3.0/24
     # List of nameserver IPs to use when creating a cluster network.
     # This is only used if neither of networkFilter and subnetFilter are given
+    # @schema
+    # type: [array, null]
+    # items:
+    #   format: ipv4
+    # @schema
     dnsNameservers:
 
 # Settings for registry mirrors
 # When a mirror is set, it will be tried for images but will fall back to the
 # upstream registry if the image pull fails
 # By default, use images mirrored to quay.io when possible
+# @schema
+# additionalProperties: true
+# @schema
 registryMirrors:
+  # @schema
+  # type: array
+  # @schema
   # docker.io:
   #   upstream: https://registry-1.docker.io
   #   mirrors:
@@ -121,16 +249,31 @@ registryMirrors:
   #       capabilities: ["pull", "resolve"]
   docker.io:
     - https://quay.io/v2/azimuth/docker.io
+  # @schema
+  # type: array
+  # @schema
   ghcr.io:
     - https://quay.io/v2/azimuth/ghcr.io
+  # @schema
+  # type: array
+  # @schema
   nvcr.io:
     - https://quay.io/v2/azimuth/nvcr.io
+  # @schema
+  # type: array
+  # @schema
   quay.io:
     - https://quay.io/v2/azimuth/quay.io
+  # @schema
+  # type: array
+  # @schema
   registry.k8s.io:
     - https://quay.io/v2/azimuth/registry.k8s.io
 
 # A map of trusted CAs to add to the system trust on cluster nodes
+# @schema
+# additionalProperties: true
+# @schema
 trustedCAs: {}
   # custom-ca: |
   #   -----BEGIN CERTIFICATE-----
@@ -138,36 +281,86 @@ trustedCAs: {}
   #   -----END CERTIFICATE-----
 
 # List of additional packages to install on cluster nodes
+# @schema
+# type: array
+# items:
+#   type: string
+# @schema
 additionalPackages: []
   # - nfs-common
 
+# @schema
+# type: object
+# @schema
 # Settings for etcd
 etcd:
+  # @schema
+  # type: string
+  # @schema
   # The data directory to use for etcd
   # When a block device is specified, it is mounted at the parent directory, e.g. /var/lib/etcd
   # This is to avoid etcd complaining about the lost+found directory
   dataDir: /var/lib/etcd
   # Any extra command line arguments to pass to etcd
+  # @schema
+  # additionalProperties: true
+  # @schema
   extraArgs:
+    # @schema
+    # type: string
+    # @schema
     # Set timeouts so that etcd tolerates 'slowness' (network + disks) better
     # This is at the expense of taking longer to detect a leader failure
     # https://etcd.io/docs/v3.5/tuning/#time-parameters
     heartbeat-interval: "500"  # defaults to 100ms in etcd 3.5
+    # @schema
+    # type: string
+    # @schema
     election-timeout: "5000"   # defaults to 1000ms in etcd 3.5
+    # @schema
+    # type: string
+    # @schema
     # Set a slightly larger space quota than the default (default is 2GB)
     quota-backend-bytes: "4294967296"
+    # @schema
+    # type: string
+    # @schema
     # Listen for metrics on 0.0.0.0 so Prometheus can collect them
     listen-metrics-urls: http://0.0.0.0:2381
+  # @schema
+  # type: object
+  # @schema
   # At-rest encryption settings
   encryption:
+    # @schema
+    # type: boolean
+    # @schema
     enabled: false
+    # @schema
+    # type: array
+    # @schema
     # K8s resources to encrypt
     resources:
       - secrets
-    # Encyption provider, see https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#providers
+    # @schema
+    # type: string
+    # @schema
+    # Encryption provider, see https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#providers
     provider: secretbox
   # The block device configuration for etcd
   # If not specified, the root device is used
+  # @schema
+  # type: [object, null]
+  # properties:
+  #   size:
+  #     type: integer
+  #   type:
+  #     enum: [Volume, Local]
+  #   volumeType:
+  #     type: [string, null]
+  #   availabilityZone:
+  #     type: [string, null]
+  # @schema
   blockDevice:
     # # The size of the block device
     # size: 20
@@ -182,29 +375,61 @@ etcd:
     # # If not specified, the machine availability zone is used
     # availabilityZone:
 
+# @schema
+# type: object
+# @schema
 # Settings for the Kubernetes API server
 apiServer:
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates whether to deploy a load balancer for the API server
   enableLoadBalancer: true
   # Indicates what loadbalancer provider to use. Default is amphora
+  # @schema
+  # type: [string, null]
+  # @schema
   loadBalancerProvider:
   # Restrict loadbalancer access to select IPs
-  # allowedCIDRs
+  # @schema
+  # type: boolean
+  # items:
+  #   type: [array, null]
+  # @schema
+  # allowedCidrs:
   #  - 192.168.0.0/16  # needed for cluster to init
   #  - 10.10.0.0/16  # IPv4 Internal Network
   #  - 123.123.123.123 # some other IPs
+  allowedCIDRs: []
   # Indicates whether to associate a floating IP with the API server
+  # @schema
+  # type: boolean
+  # @schema
   associateFloatingIP: true
   # The specific floating IP to associate with the API server
   # If not given, a new IP will be allocated if required
+  # @schema
+  # type: [string, null]
+  # format: ipv4
+  # @schema
   floatingIP:
   # The specific fixed IP to associate with the API server
   # If enableLoadBalancer is true, this will become the VIP of the load balancer
   # If enableLoadBalancer and associateFloatingIP are both false, this should be
   # the IP of a pre-allocated port to be used as the VIP
+  # @schema
+  # type: [string, null]
+  # format: ipv4
+  # @schema
   fixedIP:
+  # @schema
+  # type: integer
+  # @schema
   # The port to use for the API server
   port: 6443
+  # @schema
+  # type: integer
+  # @schema
   # Log level
   # 0: Errors
   # 1: Config info and correctable errors (e.g unhealthy node)
@@ -215,96 +440,218 @@ apiServer:
   logLevel: 2
   # The configuration for the built-in admission controllers
   # This should be a map of the controller name to the configuration for the controller
+  # @schema
+  # type: [object,null]
+  # additionalProperties: true
+  # @schema
   admissionConfiguration:
-    # PodSecurity:
-    #   apiVersion: pod-security.admission.config.k8s.io/v1
-    #   kind: PodSecurityConfiguration
-    #   defaults:
-    #     enforce: baseline
-    #     enforce-version: latest
-    #     audit: restricted
-    #     audit-version: latest
-    #     warn: restricted
-    #     warn-version: latest
-    #   exemptions:
-    #     usernames: []
-    #     runtimeClasses: []
-    #     namespaces:
-    #       - kube-system
+  #   PodSecurity:
+  #     apiVersion: pod-security.admission.config.k8s.io/v1
+  #     kind: PodSecurityConfiguration
+  #     defaults:
+  #       enforce: baseline
+  #       enforce-version: latest
+  #       audit: restricted
+  #       audit-version: latest
+  #       warn: restricted
+  #       warn-version: latest
+  #     exemptions:
+  #       usernames: []
+  #       runtimeClasses: []
+  #       namespaces:
+  #         - kube-system
 
+# @schema
+# type: string
+# @schema
 # Set osDistro used. ubuntu, flatcar, etc.
 osDistro: ubuntu
-#
+
 # API server authentication/authorization webhook. Set this to
 # integrate into KubeadmControlPlane and KubeadmConfigTemplate
-# possible values: none, k8s-keystone-auth, azimuth-authorization-webhook
+# @schema
+# enum: [none, k8s-keystone-auth, azimuth-authorization-webhook]
+# @schema
 authWebhook: none
 
+# @schema
+# type: object
+# @schema
 azimuthAuthorizationWebhook:
+  # @schema
+  # type: [string, null]
+  # @schema
   server:  # required, e.g https://example.com/authorize
+  # @schema
+  # type: string
+  # @schema
   webhookVersion: v1
+  # @schema
+  # type: string
+  # @schema
   timeout: 10s
+  # @schema
+  # type: string
+  # @schema
   failurePolicy: Deny
+  # @schema
+  # type: array
+  # @schema
   additionalAuthorizers:
     - type: Node
       name: node
     - type: RBAC
       name: rbac
+  # @schema
+  # type: object
+  # @schema
   tls:
+    # @schema
+    # type: boolean
+    # @schema
     enabled: true
+    # @schema
+    # type: [string, null]
+    # @schema
     cert:  # required
+  # @schema
+  # type: array
+  # @schema
   # Should at least include the values provided to .Values.protectedNamespaces in
   # https://github.com/azimuth-cloud/azimuth-authorization-webhook/blob/main/chart/values.yaml
   filteredNamespaces:
   - kube-system
   - openstack-system
+    # @schema
+    # type: array
+    # items:
+    #   type: string
+    # @schema
   extraPreFilters: []
 
+# @schema
+# type: object
+# @schema
 # Settings for the control plane
 controlPlane:
   # The failure domains to use for control plane nodes
   # If given, should be a list of availability zones
   # Only used when omitFailureDomain = false
+  # @schema
+  # type: [array, null]
+  # items:
+  #   type: string
+  # @schema
   failureDomains:
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates whether the failure domain should be omitted from control plane nodes
   omitFailureDomain: true
+  # @schema
+  # type: integer
+  # @schema
   # The number of control plane machines to deploy
   # For high-availability, this should be greater than 1
   # For etcd quorum, it should be odd - usually 3, or 5 for very large clusters
   machineCount: 3
   # The kubernetes version for the control plane
+  # @schema
+  # type: [string, null]
+  # pattern: 1.[0-9][0-9].[0-9]+
+  # @schema
   kubernetesVersion:
   # The image to use for control plane
+  # @schema
+  # type: [string, null]
+  # @schema
   machineImage:
   # The ID of the image to use for the control plane
+  # @schema
+  # type: [string, null]
+  # @schema
   machineImageId:
   # The flavor to use for control plane machines
+  # @schema
+  # type: [string, null]
+  # @schema
   machineFlavor:
+  # @schema
+  # type: object
+  # @schema
   # The ports for control plane nodes
   # If no ports are given, the cluster internal network is used
   # See https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/master/docs/book/src/clusteropenstack/configuration.md#network-filters
   machineNetworking:
+    # @schema
+    # type: [object, null]
+    # additionalProperties: true
+    # @schema
     ports:
+  # @schema
+  # type: object
+  # @schema
   # The root volume spec for control plane machines
   machineRootVolume:
     # The size of the disk to use
     # If not given, the ephemeral root disk from the flavor is used
+    # @schema
+    # type: [integer, null]
+    # minimum: 20
+    # @schema
     diskSize:
     # The volume type to use
     # If not specified, the default volume type is used
-    # volumeType:
+    # @schema
+    # type: [string, null]
+    # @schema
+    volumeType:
     # The volume availability zone to use
     # If not specified, the machine availability zone is used
-    # availabilityZone:
+    # @schema
+    # type: [string, null]
+    # @schema
+    availabilityZone:
   # Specific metadata for control plane nodes
+  # @schema
+  # additionalProperties: true
+  # @schema
   machineMetadata: {}
   # The ID of the server group to use for control plane machines
+  # @schema
+  # type: [string, null]
+  # @schema
   serverGroupId:
   # Labels to apply to the node objects in Kubernetes that correspond to control plane machines
+  # @schema
+  # type: [object, null]
+  # patternProperties:
+  #   ".*":
+  #     type: string
+  # @schema
   nodeLabels:
     # my.company.org/label: value
   # Additional block devices for control plane machines
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # patternProperties:
+  #   ".*":
+  #     type: object
+  #     properties:
+  #       size:
+  #         type: integer
+  #       type:
+  #         enum: [Volume, Local]
+  #       volumeType:
+  #         type: [string, null]
+  #       availabilityZone:
+  #         type: [string, null]
+  # @schema
   additionalBlockDevices: {}
+  # @schema
+  # type: boolean
+  # @schema
     # # The key is the name for the block device in the context of the machine
     # # It is also used to tag the block device, so that the volume can be identified in instance metadata
     # scratch:
@@ -323,71 +670,195 @@ controlPlane:
     #   availabilityZone:
   # Indicates whether control plane machines should use config drive or not
   machineConfigDrive: false
+  # @schema
+  # type: string
+  # @schema
   # The time to wait for a node to finish draining before it can be removed
   nodeDrainTimeout: 5m0s
+  # @schema
+  # type: string
+  # @schema
   # The time to wait for a node to detach all volumes before it can be removed
   nodeVolumeDetachTimeout: 5m0s
+  # @schema
+  # type: string
+  # @schema
   # The time to wait for the node resource to be deleted in Kubernetes when a
   # machine is marked for deletion
   nodeDeletionTimeout: 5m0s
+  # @schema
+  # type: object
+  # @schema
   # The remediation strategy for the control plane nodes
   # We set these so that we don't keep remediating an unhealthy control plane forever
   remediationStrategy:
+    # @schema
+    # type: integer
+    # @schema
     # The maximum number of times that a remediation will be retried
     maxRetry: 3
+    # @schema
+    # type: string
+    # @schema
     # The amount of time that a node created as a remediation has to become healthy
     # before the remediation is retried
     retryPeriod: 20m
+    # @schema
+    # type: string
+    # @schema
     # The length of time that a node must be healthy before any future problems are
     # considered unrelated to the previous ones (i.e. the retry count is reset)
     minHealthyPeriod: 1h
   # The rollout strategy to use for the control plane nodes
   # By default, the strategy allows the control plane to begin provisioning new nodes
   # without first tearing down old ones
+  # @schema
+  # $ref: https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/controlplane.cluster.x-k8s.io/kubeadmcontrolplane_v1beta1.json#/properties/spec/properties/rolloutStrategy
+  # additionalProperties: false
+  # @schema
   rolloutStrategy:
+    # @schema
+    # type: string
+    # @schema
     type: RollingUpdate
+    # @schema
+    # type: object
+    # @schema
     rollingUpdate:
+      # @schema
+      # type: integer
+      # @schema
       # For the control plane, this can only be 0 or 1
       maxSurge: 1
+
+  # NOTE(sd109): We can't use the official kubeadmConfigSpec schema from
+  # https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/controlplane.cluster.x-k8s.io/kubeadmcontrolplane_v1beta1.json#/properties/spec/properties/kubeadmConfigSpec
+  # because we've augmented that schema with an additional kubeProxyConfiguration field
+
   # The kubeadm config specification for the control plane
   # By default, this uses a simple configuration that enables the external cloud provider
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # @schema
   kubeadmConfigSpec:
+    # @schema
+    # type: object
+    # @schema
     initConfiguration:
+      # @schema
+      # type: object
+      # @schema
       nodeRegistration:
+        # @schema
+        # type: string
+        # @schema
         name: '{{ local_hostname }}'
+        # @schema
+        # type: object
+        # @schema
         kubeletExtraArgs:
+          # @schema
+          # type: string
+          # @schema
           cloud-provider: external
+    # @schema
+    # type: object
+    # @schema
     # As well as enabling an external cloud provider, we set the bind addresses for the
     # controller-manager, scheduler and kube-proxy to 0.0.0.0 so that Prometheus can reach
     # them to collect metrics
     clusterConfiguration:
+      # @schema
+      # type: object
+      # @schema
       controllerManager:
+        # @schema
+        # type: object
+        # @schema
         extraArgs:
+          # @schema
+          # type: string
+          # @schema
           cloud-provider: external
+          # @schema
+          # type: string
+          # @schema
           bind-address: 0.0.0.0
+      # @schema
+      # type: object
+      # @schema
       scheduler:
+        # @schema
+        # type: object
+        # @schema
         extraArgs:
+          # @schema
+          # type: string
+          # @schema
           bind-address: 0.0.0.0
+    # @schema
+    # type: object
+    # @schema
     joinConfiguration:
+      # @schema
+      # type: object
+      # @schema
       nodeRegistration:
+        # @schema
+        # type: string
+        # @schema
         name: '{{ local_hostname }}'
+        # @schema
+        # type: object
+        # @schema
         kubeletExtraArgs:
+          # @schema
+          # type: string
+          # @schema
           cloud-provider: external
+    # @schema
+    # type: object
+    # @schema
     kubeProxyConfiguration:
+      # @schema
+      # type: string
+      # @schema
       metricsBindAddress: 0.0.0.0:10249
+  # @schema
+  # type: object
+  # @schema
   # The machine health check for auto-healing of the control plane
-  # See https://cluster-api.sigs.k8s.io/tasks/healthcheck.html
+  # See https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking
   healthCheck:
+    # @schema
+    # type: boolean
+    # @schema
     # Indicates if the machine health check should be enabled
     enabled: true
     # The spec for the health check
+    # @schema
+    # additionalProperties: true
+    # @schema
     spec:
+      # @schema
+      # type: integer
+      # @schema
       # By default, don't remediate control plane nodes when more than one is unhealthy
       maxUnhealthy: 1
+      # @schema
+      # type: string
+      # @schema
       # If a node takes longer than 30 mins to startup, remediate it
       nodeStartupTimeout: 30m0s
       # By default, consider a control plane node that has not been Ready
       # for more than 5 mins unhealthy
+      # @schema
+      # type: array
+      # items:
+      #   type: object
+      #   additionalProperties: true
+      # @schema
       unhealthyConditions:
         - type: Ready
           status: Unknown
@@ -396,100 +867,243 @@ controlPlane:
           status: "False"
           timeout: 5m0s
 
+# @schema
+# type: object
+# @schema
 # Defaults for node groups
 # Each of these can be overridden in the specification for an individual node group
 nodeGroupDefaults:
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates if the node group should be autoscaled
   autoscale: false
   # The failure domain for the node group
+  # @schema
+  # type: [string, null]
+  # @schema
   failureDomain:
   # The flavor to use for machines in the node group
+  # @schema
+  # type: [string, null]
+  # @schema
   machineFlavor:
   # Default image id for nodeGroup hosts
+  # @schema
+  # type: [string, null]
+  # @schema
   machineImage:
   # The ID of the image to use for nodeGroup machines
+  # @schema
+  # type: [string, null]
+  # @schema
   machineImageId:
   # Kubernetes version for nodeGroup machines
+  # @schema
+  # type: [string, null]
+  # pattern: 1.[0-9][0-9].[0-9]+
+  # @schema
   kubernetesVersion:
+  # @schema
+  # type: object
+  # @schema
   # The default networks and ports for worker nodes
   # If neither networks or ports are given, the cluster internal network is used
   # The default ports for worker nodes
   # If no ports are given, the cluster internal network is used
   # See https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/master/docs/book/src/clusteropenstack/configuration.md#network-filters
   machineNetworking:
+    # @schema
+    # type: [object, null]
+    # additionalProperties: true
+    # @schema
     ports:
+  # @schema
+  # type: object
+  # @schema
   # The root volume spec for machines in the node group
   machineRootVolume:
     # The size of the disk to use
     # If not given, the ephemeral root disk from the flavor is used
+    # @schema
+    # type: [integer, null]
+    # minimum: 20
+    # @schema
     diskSize:
     # The volume type to use
     # If not specified, the default volume type is used
-    # volumeType:
+    # @schema
+    # type: [string, null]
+    # @schema
+    volumeType:
     # The volume availability zone to use
     # If not specified, the machine availability zone is used
-    # availabilityZone:
+    # @schema
+    # type: [string, null]
+    # @schema
+    availabilityZone:
   # Specific metadata for worker nodes
   # Can also be specified for each node group
+  # @schema
+  # additionalProperties: true
+  # @schema
   machineMetadata: {}
   # The ID of the server group to use for machines in the node group
+  # @schema
+  # type: [string, null]
+  # @schema
   serverGroupId:
   # Labels to apply to the node objects in Kubernetes that correspond to machines in the node group
   # By default, nodes get the label "capi.stackhpc.com/node-group=<node group name>"
+  # @schema
+  # type: [object, null]
+  # patternProperties:
+  #   ".*":
+  #     type: string
+  # @schema
   nodeLabels:
     # my.company.org/label: value
   # Additional block devices for node groups machines
   # Options are the same as for controlPlane.additionalBlockDevices above
+  # @schema
+  # type: object
+  # additionalProperties: true
+  # patternProperties:
+  #   ".*":
+  #     type: object
+  #     properties:
+  #       size:
+  #         type: integer
+  #       type:
+  #         enum: [Volume, Local]
+  #       volumeType:
+  #         type: [string, null]
+  #       availabilityZone:
+  #         type: [string, null]
+  # @schema
   additionalBlockDevices: {}
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates whether control plane machines should use config drive or not
   machineConfigDrive: false
+  # @schema
+  # type: string
+  # @schema
   # The time to wait for a node to finish draining before it can be removed
   nodeDrainTimeout: 5m0s
+  # @schema
+  # type: string
+  # @schema
   # The time to wait for a node to detach all volumes before it can be removed
   nodeVolumeDetachTimeout: 5m0s
+  # @schema
+  # type: string
+  # @schema
   # The time to wait for the node resource to be deleted in Kubernetes when a
   # machine is marked for deletion
   nodeDeletionTimeout: 5m0s
   # The rollout strategy to use for the node group
   # By default, this is set to do a rolling update within the existing resource envelope
   # of the node group, even if that means the node group temporarily has zero nodes
+  # @schema
+  # $ref: https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cluster.x-k8s.io/machinedeployment_v1beta1.json#/properties/spec/properties/strategy
+  # additionalProperties: false
+  # @schema
   rolloutStrategy:
+    # @schema
+    # type: string
+    # @schema
     type: RollingUpdate
+    # @schema
+    # type: object
+    # @schema
     rollingUpdate:
+      # @schema
+      # type: integer
+      # @schema
       # The maximum number of node group machines that can be unavailable during the update
       # Can be an absolute number or a percentage of the desired count
       maxUnavailable: 1
+      # @schema
+      # type: integer
+      # @schema
       # The maximum number of machines that can be scheduled above the desired count for
       # the group during an update
       # Can be an absolute number or a percentage of the desired count
       maxSurge: 0
+      # @schema
+      # type: string
+      # @schema
       # One of Random, Newest, Oldest
       deletePolicy: Random
   # The default kubeadm config specification for worker nodes
   # This will be merged with any configuration given for specific node groups
   # By default, this uses a simple configuration that enables the external cloud provider
+  # TODO: Can we refer to subsection of external schema instead?
+  # https://github.com/datreeio/CRDs-catalog/blob/main/bootstrap.cluster.x-k8s.io/kubeadmconfigtemplate.json#/properties/spec/template/spec
+  # @schema
+  # $ref: https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/bootstrap.cluster.x-k8s.io/kubeadmconfigtemplate_v1beta1.json#/properties/spec/properties/template/properties/spec
+  # additionalProperties: false
+  # @schema
   kubeadmConfigSpec:
+    # @schema
+    # type: object
+    # @schema
     joinConfiguration:
+      # @schema
+      # type: object
+      # @schema
       nodeRegistration:
+        # @schema
+        # type: string
+        # @schema
         name: '{{ local_hostname }}'
+        # @schema
+        # type: object
+        # @schema
         kubeletExtraArgs:
+          # @schema
+          # type: string
+          # @schema
           cloud-provider: external
+  # @schema
+  # type: object
+  # @schema
   # The default machine health check for worker nodes
   # See https://cluster-api.sigs.k8s.io/tasks/healthcheck.html
   # Note that maxUnhealthy or unhealthRange are evaluated per node group
   healthCheck:
+    # @schema
+    # type: boolean
+    # @schema
     # Indicates if the machine health check should be enabled
     enabled: true
     # The spec for the health check
+    # @schema
+    # additionalProperties: true
+    # @schema
     spec:
       # We have a control place feature gate enabled which blocks all worker node remediation if
       # control plane is unhealthy, so should be safe to reset worker remediation threshold to
       # 100% without the risk of runaway remediations.
+      # @schema
+      # type: [string, integer]
+      # @schema
       maxUnhealthy: 100%
+      # @schema
+      # type: string
+      # @schema
       # If a node takes longer than 30 mins to startup, remediate it
       nodeStartupTimeout: 30m0s
       # By default, consider a worker node that has not been Ready for
       # more than 5 mins unhealthy
+      # @schema
+      # type: array
+      # items:
+      #   type: object
+      #   additionalProperties: true
+      # @schema
       unhealthyConditions:
         - type: Ready
           status: Unknown
@@ -499,6 +1113,13 @@ nodeGroupDefaults:
           timeout: 5m0s
 
 # The worker node groups for the cluster
+# See nodeGroupDefaults schema for details
+# @schema
+# type: array
+# items:
+#   type: object
+#   additionalProperties: true
+# @schema
 nodeGroups:
   -  # The name of the node group
     name: md-0
@@ -508,57 +1129,160 @@ nodeGroups:
     # machineCountMin: 3
     # machineCountMax: 3
 
+# @schema
+# type: object
+# @schema
 # Configuration for the cluster autoscaler
 autoscaler:
+  # @schema
+  # type: object
+  # @schema
   # The image to use for the autoscaler component
   image:
+    # @schema
+    # type: string
+    # @schema
     repository: registry.k8s.io/autoscaling/cluster-autoscaler
+    # @schema
+    # type: string
+    # @schema
     pullPolicy: IfNotPresent
+    # @schema
+    # type: string
+    # @schema
     tag: v1.30.4
+  # @schema
+  # type: array
+  # items:
+  #   type: object
+  #   properties:
+  #     name:
+  #       type: [string, null]
+  # @schema
   imagePullSecrets: []
   # Any extra args for the autoscaler
+  # @schema
+  # additionalProperties: true
+  # @schema
   extraArgs:
+    # @schema
+    # type: boolean
+    # @schema
     # Make sure logs go to stderr
     logtostderr: true
+    # @schema
+    # type: string
+    # @schema
     stderrthreshold: info
+    # @schema
+    # type: integer
+    # @schema
     # Output at a decent log level
     v: 4
+    # @schema
+    # type: string
+    # @schema
     # Cordon nodes before terminating them so new pods are not scheduled there
     cordon-node-before-terminating: "true"
+    # @schema
+    # type: string
+    # @schema
     # When scaling up, choose the node group that will result in the least idle CPU after
     expander: least-waste,random
+    # @schema
+    # type: string
+    # @schema
     # Allow pods in kube-system to prevent a node from being deleted
     skip-nodes-with-system-pods: "true"
+    # @schema
+    # type: string
+    # @schema
     # Allow pods with emptyDirs to be evicted
     skip-nodes-with-local-storage: "false"
+    # @schema
+    # type: string
+    # @schema
     # Allow pods with custom controllers to be evicted
     skip-nodes-with-custom-controller-pods: "false"
 
   # Pod-level security context
+  # @schema
+  # $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/podsecuritycontext-v1.json
+  # additionalProperties: false
+  # @schema
   podSecurityContext:
+    # @schema
+    # type: boolean
+    # @schema
     runAsNonRoot: true
+    # @schema
+    # type: integer
+    # @schema
     runAsUser: 1001
   # Container-level security context
+  # @schema
+  # $ref: https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.34.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext
+  # additionalProperties: false
+  # @schema
   securityContext:
+    # @schema
+    # type: boolean
+    # @schema
     allowPrivilegeEscalation: false
+    # @schema
+    # type: object
+    # @schema
     capabilities:
+      # @schema
+      # type: array
+      # @schema
       drop: [ALL]
+    # @schema
+    # type: boolean
+    # @schema
     readOnlyRootFilesystem: true
   # Resource requests and limits for pods
+  # @schema
+  # additionalProperties: true
+  # @schema
   resources: {}
   # Node selector for pods
+  # @schema
+  # additionalProperties: true
+  # @schema
   nodeSelector: {}
+  # @schema
+  # type: array
+  # @schema
   # Tolerations for pods
   tolerations: []
+  # @schema
+  # type: array
+  # @schema
   # Topology spread constraints for pods
   topologySpreadConstraints: []
   # Affinity rules for pods
+  # @schema
+  # additionalProperties: true
+  # @schema
   affinity: {}
 
+# @schema
+# type: object
+# @schema
 # Configuration for cluster addons
 addons:
+  # @schema
+  # type: boolean
+  # @schema
   # Indicates if cluster addons should be deployed
   enabled: true
+  # @schema
+  # type: object
+  # @schema
   # Enable the openstack integrations by default
   openstack:
+    # @schema
+    # type: boolean
+    # @schema
     enabled: true

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -29,7 +29,7 @@ cloudName: openstack
 # The Kubernetes version of the cluster
 # This should match the version of kubelet and kubeadm in the image
 # @schema
-# type: string
+# type: [string, null]
 # pattern: 1.[0-9][0-9].[0-9]+
 # @schema
 kubernetesVersion:
@@ -177,8 +177,14 @@ clusterNetworking:
   # Indicates if the managed security groups should allow all in-cluster traffic
   # The default CNI installed by the addons is Cilium, so this is true by default
   allowAllInClusterTraffic: true
+  # @schema
+  # type: array
+  # @schema
   # Defines the rules that should be applied to worker nodes.
   workerNodesSecurityGroupRules: []
+  # @schema
+  # type: array
+  # @schema
   # Defines the rules that should be applied to control plane nodes.
   controlPlaneNodesSecurityGroupRules: []
   # The ID of the external network to use
@@ -392,9 +398,9 @@ apiServer:
   loadBalancerProvider:
   # Restrict loadbalancer access to select IPs
   # @schema
-  # type: boolean
+  # type: array
   # items:
-  #   type: [array, null]
+  #   type: [string]
   # @schema
   # allowedCidrs:
   #  - 192.168.0.0/16  # needed for cluster to init


### PR DESCRIPTION
The values files in these charts are growing increasingly complex and it's easy to accidentally miss some indentation or make a typo when setting Helm values. Helm includes built-in support for validating a values file format against a provided JSON schema which can help avoid trivial config errors.

This change adds a values schema generated using the [helm-schema](https://github.com/dadav/helm-schema) plugin and adds appropriate `@schema` annotations to the values files to constrain the schema for config options which cannot be automatically inferred from their default values.