### PR TITLE
Restore write permissions to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -14,6 +14,8 @@ jobs:
   build_push_charts:
     name: Build and push Helm charts
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       chart-version: ${{ steps.semver.outputs.version }}
     steps:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,6 +19,8 @@ jobs:
 
   publish_dependencies:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   propose_update_pr:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Since setting all GITHUB_TOKEN to read-only at the Org-level, some jobs need their implicit write permissions restored.