### PR TITLE
Correct case for allowedCIDRs

### DIFF
--- a/charts/openstack-cluster/templates/cluster-openstack.yaml
+++ b/charts/openstack-cluster/templates/cluster-openstack.yaml
@@ -52,9 +52,9 @@ spec:
     {{- if .loadBalancerProvider }}
     provider: {{ .loadBalancerProvider }}
     {{- end }}
-    {{- if .allowedCidrs }}
-    allowedCidrs:
-      {{- range .allowedCidrs }}
+    {{- if .allowedCIDRs }}
+    allowedCIDRs:
+      {{- range .allowedCIDRs }}
       - {{ . }}
       {{- end}}
     {{- end }}

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -185,7 +185,7 @@ apiServer:
   # Indicates what loadbalancer provider to use. Default is amphora
   loadBalancerProvider:
   # Restrict loadbalancer access to select IPs
-  # allowedCidrs
+  # allowedCIDRs
   #  - 192.168.0.0/16  # needed for cluster to init
   #  - 10.10.0.0/16  # IPv4 Internal Network
   #  - 123.123.123.123 # some other IPs


### PR DESCRIPTION
Closes #675

Docs for v1beta1 object: https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api-provider-openstack/infrastructure.cluster.x-k8s.io/OpenStackCluster/v1beta1@v0.14.1#spec-apiServerLoadBalancer-allowedCIDRs