### PR TITLE
Configure worker and control-plane security groups

### DIFF
--- a/charts/openstack-cluster/templates/_helpers.tpl
+++ b/charts/openstack-cluster/templates/_helpers.tpl
@@ -576,3 +576,39 @@ Produces integration for azimuth_authorization_webhook on apiserver
             name: {{ .name }}
           {{- end }}
 {{- end }}
+
+{{/*
+Return a list of security groups to apply to worker nodes when
+OVN is the apiserver loadbalancer provider
+*/}}
+{{- define "openstack-cluster.workerNodesSecurityGroupRulesOVN" }}
+workerNodeSecurityGroupRules:
+  - name: Worker nodePort TCP
+    remoteIPPrefix: 0.0.0.0/0
+    protocol: tcp
+    direction: ingress
+    etherType: IPv4
+    portRangeMin: 30000
+    portRangeMax: 32767
+  - name: Worker nodePort UDP
+    protocol: udp
+    remoteIPPrefix: 0.0.0.0/0
+    direction: ingress
+    etherType: IPv4
+    portRangeMin: 30000
+    portRangeMax: 32767
+{{- end }}
+
+{{/*
+Creates a list of security group rules to apply to worker nodes
+*/}}
+{{- define "openstack-cluster.workerNodesSecurityGroupRules" }}
+{{- $msecgroups := index . 0 }}
+{{- $ovnapiserver := index . 1 }}
+{{- if $ovnapiserver }}
+{{- $ovn := include "openstack-cluster.workerNodesSecurityGroupRulesOVN" $ovnapiserver | fromYaml }}
+{{- concat $msecgroups.workerNodeSecurityGroupRules $ovn.workerNodeSecurityGroupRules | uniq | toYaml }}
+{{- else }}
+{{- toYaml $msecgroups.workerNodeSecurityGroupRules }}
+{{- end }}
+{{- end }}

--- a/charts/openstack-cluster/templates/cluster-openstack.yaml
+++ b/charts/openstack-cluster/templates/cluster-openstack.yaml
@@ -22,22 +22,11 @@ spec:
   {{- if .manageSecurityGroups }}
   managedSecurityGroups:
     allowAllInClusterTraffic: {{ .allowAllInClusterTraffic }}
-    {{- if eq $.Values.apiServer.loadBalancerProvider "ovn" }}
-    workerNodesSecurityGroupRules:
-      - name: Worker nodePort TCP
-        remoteIPPrefix: 0.0.0.0/0
-        protocol: tcp
-        direction: ingress
-        etherType: IPv4
-        portRangeMin: 30000
-        portRangeMax: 32767
-      - name: Worker nodePort UDP
-        protocol: udp
-        remoteIPPrefix: 0.0.0.0/0
-        direction: ingress
-        etherType: IPv4
-        portRangeMin: 30000
-        portRangeMax: 32767
+    {{- if or (eq $.Values.apiServer.loadBalancerProvider "ovn") .workerNodeSecurityGroupRules }}
+    workerNodeSecurityGroupRules: {{ include "openstack-cluster.workerNodesSecurityGroupRules" ( list . (eq $.Values.apiServer.loadBalancerProvider "ovn")) | nindent 6 }}
+    {{- end }}
+    {{- if .controlPlaneNodesSecurityGroupRules }}
+    controlPlaneNodesSecurityGroupRules: {{ .controlPlaneNodesSecurityGroupRules | nindent 6 }}
     {{- end }}
   {{- end }}
   {{- with .externalNetworkId }}

--- a/charts/openstack-cluster/tests/__snapshot__/snapshot_ovn_test.yaml.snap
+++ b/charts/openstack-cluster/tests/__snapshot__/snapshot_ovn_test.yaml.snap
@@ -1,0 +1,1625 @@
+templated manifests should match snapshot:
+  1: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        addons.stackhpc.com/watch: ""
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: cni-calico
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-cni-calico-config
+    stringData:
+      defaults: |
+        installation:
+          nodeMetricsPort: 9091
+          typhaMetricsPort: 9093
+          calicoNetwork:
+            bgp: Disabled
+            nodeAddressAutodetectionV4:
+              kubernetes: NodeInternalIP
+            ipPools:
+        {% for cidr in cluster.spec.clusterNetwork.pods.cidrBlocks %}
+              - blockSize: 26
+                cidr: {{ cidr }}
+                disableBGPExport: false
+                encapsulation: VXLAN
+                natOutgoing: Enabled
+                nodeSelector: all()
+        {% endfor %}
+      overrides: |
+        nodeSelector:
+          node-role.kubernetes.io/control-plane: ""
+  2: |
+    apiVersion: addons.stackhpc.com/v1alpha1
+    kind: HelmRelease
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: cni-calico
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-cni-calico
+    spec:
+      bootstrap: true
+      chart:
+        name: tigera-operator
+        repo: https://projectcalico.docs.tigera.io/charts
+        version: v3.31.5
+      clusterName: RELEASE-NAME
+      releaseName: cni-calico
+      targetNamespace: tigera-operator
+      valuesSources:
+        - secret:
+            key: defaults
+            name: RELEASE-NAME-cni-calico-config
+        - secret:
+            key: overrides
+            name: RELEASE-NAME-cni-calico-config
+  3: |
+    apiVersion: addons.stackhpc.com/v1alpha1
+    kind: Manifests
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: cni-calico-globalnetpolicy
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-cni-calico-globalnetpolicy
+    spec:
+      bootstrap: true
+      clusterName: RELEASE-NAME
+      manifestSources:
+        - template: "---\napiVersion: projectcalico.org/v3\nkind: GlobalNetworkPolicy\nmetadata:\n  name: default.RELEASE-NAME-deny-egress\nspec:\n  order: 10\n  namespaceSelector: kubernetes.io/metadata.name != 'openstack-system'\n  types:\n    - Egress\n  egress:\n    - action: Deny\n      ipVersion: 4\n      destination:\n        nets:\n          - 169.254.169.254/32\n        \n    - action: Deny\n      ipVersion: 6\n      destination:\n        nets:\n          - fe80::a9fe:a9fe/128\n        \n---\napiVersion: projectcalico.org/v3\nkind: GlobalNetworkPolicy\nmetadata:\n  name: default.RELEASE-NAME-allow-global-egress\nspec:\n  order: 20\n  types:\n    - Egress\n  egress:\n    - action: Allow\n      ipVersion: 4\n      destination:\n        nets:\n          - 0.0.0.0/0\n        \n    - action: Allow\n      ipVersion: 6\n      destination:\n        nets:\n          - ::/0\n        \n"
+      releaseName: cni-calico-metadata-global-netpolicy
+      targetNamespace: tigera-operator
+  4: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        addons.stackhpc.com/watch: ""
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: etcd-defrag
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-etcd-defrag-config
+    stringData:
+      overrides: |
+        {}
+  5: |
+    apiVersion: addons.stackhpc.com/v1alpha1
+    kind: HelmRelease
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: etcd-defrag
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-etcd-defrag
+    spec:
+      bootstrap: true
+      chart:
+        name: etcd-defrag
+        repo: https://azimuth-cloud.github.io/capi-helm-charts
+        version: 0.1.0
+      clusterName: RELEASE-NAME
+      releaseName: etcd-defrag
+      targetNamespace: kube-system
+      valuesSources:
+        - secret:
+            key: overrides
+            name: RELEASE-NAME-etcd-defrag-config
+  6: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        addons.stackhpc.com/watch: ""
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: mellanox-network-operator
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-mellanox-network-operator-config
+    stringData:
+      defaults: |
+        # Use the shared NFD
+        nfd:
+          enabled: false
+        # Deploy the default NICClusterPolicy
+        deployCR: true
+        # Deploy the OFED driver onto nodes with a suitable NIC
+        ofedDriver:
+          deploy: true
+          # OFED takes ages to deploy on low-resource nodes
+          # The startup probe has a fixed failure threshold of 60
+          # So in order to give the drivers up to one hour to install, we use a period
+          # of 60 seconds for the startup probe
+          startupProbe:
+            initialDelaySeconds: 60
+            periodSeconds: 60
+        # Deploy the RDMA shared device plugin to allow pods to access the RDMA device
+        rdmaSharedDevicePlugin:
+          deploy: true
+        # Disable all other features for now
+        ibKubernetes:
+          deploy: false
+        nvPeerDriver:
+          deploy: false
+        sriovNetworkOperator:
+          enabled: false
+        sriovDevicePlugin:
+          deploy: false
+        secondaryNetwork:
+          deploy: false
+      overrides: |
+        {}
+  7: |
+    apiVersion: addons.stackhpc.com/v1alpha1
+    kind: HelmRelease
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: mellanox-network-operator
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-mellanox-network-operator
+    spec:
+      bootstrap: true
+      chart:
+        name: network-operator
+        repo: https://helm.ngc.nvidia.com/nvidia
+        version: 26.1.1
+      clusterName: RELEASE-NAME
+      releaseName: mellanox-network-operator
+      targetNamespace: network-operator
+      valuesSources:
+        - secret:
+            key: defaults
+            name: RELEASE-NAME-mellanox-network-operator-config
+        - secret:
+            key: overrides
+            name: RELEASE-NAME-mellanox-network-operator-config
+  8: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        addons.stackhpc.com/watch: ""
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: metrics-server
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-metrics-server-config
+    stringData:
+      defaults: |
+        args:
+          - --kubelet-insecure-tls
+        # Since we deploy in kube-system, we need a PDB to allow eviction to happen
+        podDisruptionBudget:
+          enabled: true
+          maxUnavailable: 1
+      overrides: |
+        {}
+  9: |
+    apiVersion: addons.stackhpc.com/v1alpha1
+    kind: HelmRelease
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: metrics-server
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-metrics-server
+    spec:
+      bootstrap: true
+      chart:
+        name: metrics-server
+        repo: https://kubernetes-sigs.github.io/metrics-server
+        version: 3.13.0
+      clusterName: RELEASE-NAME
+      releaseName: metrics-server
+      targetNamespace: kube-system
+      valuesSources:
+        - secret:
+            key: defaults
+            name: RELEASE-NAME-metrics-server-config
+        - secret:
+            key: overrides
+            name: RELEASE-NAME-metrics-server-config
+  10: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        addons.stackhpc.com/watch: ""
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: node-feature-discovery
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-node-feature-discovery-config
+    stringData:
+      defaults: |
+        master:
+          extraLabelNs:
+            - nvidia.com
+        worker:
+          # Allow the NFD pods to be scheduled on all pods
+          tolerations:
+            - effect: "NoSchedule"
+              operator: "Exists"
+          # We want to be able to identify nodes with high-performance hardware
+          # So the whitelisted device classes are:
+          #   02   - Network Controllers (e.g. Ethernet, Infiniband)
+          #   03   - Display Controllers (e.g. GPUs)
+          #   0b40 - Co-processors
+          #   12   - Processing Accelerators (e.g. specialised AI inference chips)
+          config:
+            sources:
+              pci:
+                deviceClassWhitelist:
+                  - "02"
+                  - "03"
+                  - "0b40"
+                  - "12"
+                deviceLabelFields:
+                  - vendor
+      overrides: |
+        {}
+  11: |
+    apiVersion: addons.stackhpc.com/v1alpha1
+    kind: HelmRelease
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: node-feature-discovery
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-node-feature-discovery
+    spec:
+      bootstrap: true
+      chart:
+        name: node-feature-discovery
+        repo: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+        version: 0.18.3
+      clusterName: RELEASE-NAME
+      releaseName: node-feature-discovery
+      targetNamespace: node-feature-discovery
+      valuesSources:
+        - secret:
+            key: defaults
+            name: RELEASE-NAME-node-feature-discovery-config
+        - secret:
+            key: overrides
+            name: RELEASE-NAME-node-feature-discovery-config
+  12: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        addons.stackhpc.com/watch: ""
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: node-problem-detector
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-node-problem-detector-config
+    stringData:
+      defaults: |
+        metrics:
+          enabled: false
+      overrides: |
+        {}
+  13: |
+    apiVersion: addons.stackhpc.com/v1alpha1
+    kind: HelmRelease
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: node-problem-detector
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-node-problem-detector
+    spec:
+      bootstrap: true
+      chart:
+        name: node-problem-detector
+        repo: https://charts.deliveryhero.io
+        version: 2.3.14
+      clusterName: RELEASE-NAME
+      releaseName: node-problem-detector
+      targetNamespace: node-problem-detector
+      valuesSources:
+        - secret:
+            key: defaults
+            name: RELEASE-NAME-node-problem-detector-config
+        - secret:
+            key: overrides
+            name: RELEASE-NAME-node-problem-detector-config
+  14: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        addons.stackhpc.com/watch: ""
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: nvidia-gpu-operator
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-nvidia-gpu-operator-config
+    stringData:
+      defaults: |
+        # Use the shared NFD
+        nfd:
+          enabled: false
+        # Export operator and node metrics in a Prometheus format.
+        # The component provides information on the status of the
+        # operator (e.g. reconciliation status, number of GPU enabled nodes).
+        nodeStatusExporter:
+          enabled: true
+        toolkit:
+          # Allowing the toolkit to edit /etc/containerd/config.toml (the default)
+          # breaks nvidia pod deployment on clusters with Harbor cache enabled.
+          # Instead make a new config file specifically for nvidia runtime config,
+          # which is parsed as an "include" in the main containerd config file.
+          #
+          # https://github.com/NVIDIA/gpu-operator/issues/301
+          env:
+            - name: "CONTAINERD_CONFIG"
+              value: "/etc/containerd/conf.d/nvidia.toml"
+      overrides: |
+        dcgmExporter:
+          serviceMonitor:
+            enabled: true
+  15: |
+    apiVersion: addons.stackhpc.com/v1alpha1
+    kind: HelmRelease
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: nvidia-gpu-operator
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-nvidia-gpu-operator
+    spec:
+      bootstrap: true
+      chart:
+        name: gpu-operator
+        repo: https://helm.ngc.nvidia.com/nvidia
+        version: v26.3.1
+      clusterName: RELEASE-NAME
+      releaseName: nvidia-gpu-operator
+      targetNamespace: gpu-operator
+      valuesSources:
+        - secret:
+            key: defaults
+            name: RELEASE-NAME-nvidia-gpu-operator-config
+        - secret:
+            key: overrides
+            name: RELEASE-NAME-nvidia-gpu-operator-config
+  16: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        addons.stackhpc.com/watch: ""
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: ccm-openstack
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-ccm-openstack-config
+    stringData:
+      defaults: |
+        secret:
+          create: false
+        cluster:
+          name: RELEASE-NAME
+        controllerExtraArgs: |-
+          - --use-service-account-credentials=false
+        nodeSelector:
+          node-role.kubernetes.io/control-plane: ""
+        tolerations:
+          - key: node.cloudprovider.kubernetes.io/uninitialized
+            value: "true"
+            effect: NoSchedule
+          - key: node-role.kubernetes.io/master
+            effect: NoSchedule
+          - key: node-role.kubernetes.io/control-plane
+            effect: NoSchedule
+      overrides: |
+        {}
+  17: |
+    apiVersion: addons.stackhpc.com/v1alpha1
+    kind: HelmRelease
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: ccm-openstack
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-ccm-openstack
+    spec:
+      bootstrap: true
+      chart:
+        name: openstack-cloud-controller-manager
+        repo: https://kubernetes.github.io/cloud-provider-openstack
+        version: 2.36.0
+      clusterName: RELEASE-NAME
+      releaseName: ccm-openstack
+      targetNamespace: openstack-system
+      valuesSources:
+        - secret:
+            key: defaults
+            name: RELEASE-NAME-ccm-openstack-config
+        - secret:
+            key: overrides
+            name: RELEASE-NAME-ccm-openstack-config
+  18: |
+    apiVersion: addons.stackhpc.com/v1alpha1
+    kind: Manifests
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: cloud-config
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-cloud-config
+    spec:
+      bootstrap: true
+      clusterName: RELEASE-NAME
+      manifestSources:
+        - template: "apiVersion: v1\nkind: Secret\nmetadata:\n  name: cloud-config\ndata:\n  {{ cloud_identity.data | toyaml | indent(2) }}\nstringData:\n  cloud.conf: |\n    [Global]\n    use-clouds=true\n    clouds-file=/etc/config/clouds.yaml\n    cloud=openstack\n{%- if \"cacert\" in cloud_identity.data %}\n    ca-file=/etc/config/cacert\n{%- else %}\n    tls-insecure=true\n{%- endif %}\n    [Networking]\n    internal-network-name={{ infra_cluster.status.network.name }}\n    [LoadBalancer]\n  {%- if \"externalNetwork\" in infra_cluster.status %}\n    floating-network-id={{ infra_cluster.status.externalNetwork.id }}\n  {%- endif %}\n    [BlockStorage]\n    ignore-volume-az=true\n    \n"
+      releaseName: cloud-config
+      targetNamespace: openstack-system
+  19: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        addons.stackhpc.com/watch: ""
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: csi-cinder
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-csi-cinder-config
+    stringData:
+      defaults: |
+        csi:
+          plugin:
+            # This has to be non-empty or the chart fails to render
+            volumes:
+              - name: cacert
+                emptyDir: {}
+            volumeMounts:
+              - name: cloud-config
+                mountPath: /etc/config
+                readOnly: true
+              - name: cloud-config
+                mountPath: /etc/kubernetes
+                readOnly: true
+          provisioner:
+            topology: "false"
+        secret:
+          enabled: true
+          create: false
+          name: cloud-config
+        storageClass:
+          enabled: false
+        clusterID: RELEASE-NAME
+      overrides: |
+        csi:
+          plugin:
+            controllerPlugin:
+              nodeSelector:
+                node-role.kubernetes.io/control-plane: ""
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/control-plane
+  20: |
+    apiVersion: addons.stackhpc.com/v1alpha1
+    kind: HelmRelease
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: csi-cinder
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-csi-cinder
+    spec:
+      bootstrap: true
+      chart:
+        name: openstack-cinder-csi
+        repo: https://kubernetes.github.io/cloud-provider-openstack
+        version: 2.35.0
+      clusterName: RELEASE-NAME
+      releaseName: csi-cinder
+      targetNamespace: openstack-system
+      valuesSources:
+        - secret:
+            key: defaults
+            name: RELEASE-NAME-csi-cinder-config
+        - secret:
+            key: overrides
+            name: RELEASE-NAME-csi-cinder-config
+  21: |
+    apiVersion: addons.stackhpc.com/v1alpha1
+    kind: Manifests
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: csi-cinder
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: addons-0.1.0
+      name: RELEASE-NAME-csi-cinder-storageclass
+    spec:
+      bootstrap: true
+      clusterName: RELEASE-NAME
+      manifestSources:
+        - template: |
+            apiVersion: storage.k8s.io/v1
+            kind: StorageClass
+            metadata:
+              name: csi-cinder
+              annotations:
+                storageclass.kubernetes.io/is-default-class: "true"
+            provisioner: cinder.csi.openstack.org
+            parameters:
+              availability: nova
+            reclaimPolicy: Delete
+            allowVolumeExpansion: true
+            volumeBindingMode: WaitForFirstConsumer
+      releaseName: csi-cinder-storageclass
+      targetNamespace: openstack-system
+  22: |
+    raw: |
+      DEPRECATION NOTICE:
+
+        .Values.addons.ingress.nginx.enabled=true is deprecated, therefore using capi-helm-charts to
+        install Ingress NGINX controller as an addon is deprecated.
+
+        .Values.addons.ingress.traefik.enabled=true is set by default. The supported cluster addon for
+        ingress controller and GatewayAPI is Traefik. This means that setting .Values.addons.ingress.enabled=true will now default to installing Traefik and removing Ingress NGINX if it is installed.
+
+        For safety and security reasons, Ingress NGINX was retired in
+        March 2026 [https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/]. As Ingress
+        NGINX is the only Ingress controller addon supported by capi-helm-charts,
+        capi-helm-charts can no longer deploy an Ingress controller as an addon.
+
+        - capi-helm-charts retains the ability to **enable** Ingress NGINX as a cluster addon for
+          backwards compatibility with other tooling.
+        - The deployment of Ingress NGINX will no longer be tested as part of the release
+          process for capi-helm-charts.
+        - Setting .Values.addons.ingress.enabled=true therefore no longer guarantees to install
+          a functioning NGINX Ingress controller.
+  23: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: autoscaler
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-autoscaler
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          capi.stackhpc.com/cluster: RELEASE-NAME
+          capi.stackhpc.com/component: autoscaler
+      template:
+        metadata:
+          labels:
+            capi.stackhpc.com/cluster: RELEASE-NAME
+            capi.stackhpc.com/component: autoscaler
+        spec:
+          containers:
+            - args:
+                - --cloud-provider=clusterapi
+                - --kubeconfig=/mnt/kubeconfig/value
+                - --clusterapi-cloud-config-authoritative
+                - --node-group-auto-discovery=clusterapi:namespace=NAMESPACE,clusterName=RELEASE-NAME
+                - --cordon-node-before-terminating=true
+                - --expander=least-waste,random
+                - --logtostderr=true
+                - --skip-nodes-with-custom-controller-pods=false
+                - --skip-nodes-with-local-storage=false
+                - --skip-nodes-with-system-pods=true
+                - --stderrthreshold=info
+                - --v=4
+              command:
+                - /cluster-autoscaler
+              image: registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.4
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /health-check
+                  port: 8085
+              name: autoscaler
+              ports:
+                - containerPort: 8085
+              resources: {}
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+              volumeMounts:
+                - mountPath: /mnt/kubeconfig
+                  name: kubeconfig
+                  readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          serviceAccountName: RELEASE-NAME-autoscaler
+          volumes:
+            - name: kubeconfig
+              secret:
+                secretName: RELEASE-NAME-kubeconfig
+  24: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: autoscaler
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-autoscaler
+    rules:
+      - apiGroups:
+          - cluster.x-k8s.io
+        resources:
+          - machinedeployments
+          - machines
+          - machinesets
+          - machinepools
+        verbs:
+          - get
+          - list
+          - update
+          - watch
+      - apiGroups:
+          - cluster.x-k8s.io
+        resources:
+          - machinedeployments/scale
+        verbs:
+          - get
+          - patch
+          - update
+  25: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: autoscaler
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-autoscaler
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: RELEASE-NAME-autoscaler
+    subjects:
+      - kind: ServiceAccount
+        name: RELEASE-NAME-autoscaler
+        namespace: NAMESPACE
+  26: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: autoscaler
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-autoscaler
+  27: |
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: OpenStackCluster
+    metadata:
+      annotations:
+        helm.sh/resource-policy: keep
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME
+    spec:
+      apiServerLoadBalancer:
+        enabled: true
+        provider: ovn
+      apiServerPort: 6443
+      controlPlaneOmitAvailabilityZone: true
+      disableAPIServerFloatingIP: false
+      identityRef:
+        cloudName: openstack
+        name: RELEASE-NAME-cloud-credentials
+      managedSecurityGroups:
+        allowAllInClusterTraffic: true
+        workerNodeSecurityGroupRules:
+          - direction: ingress
+            etherType: IPv4
+            name: Worker nodePort TCP
+            portRangeMax: 32767
+            portRangeMin: 30000
+            protocol: tcp
+            remoteIPPrefix: 0.0.0.0/0
+          - direction: ingress
+            etherType: IPv4
+            name: Worker nodePort TCP2
+            portRangeMax: 32767
+            portRangeMin: 30001
+            protocol: tcp
+            remoteIPPrefix: 0.0.0.0/0
+          - direction: ingress
+            etherType: IPv4
+            name: Worker nodePort UDP
+            portRangeMax: 32767
+            portRangeMin: 30000
+            protocol: udp
+            remoteIPPrefix: 0.0.0.0/0
+      managedSubnets:
+        - cidr: 192.168.3.0/24
+  28: |
+    apiVersion: cluster.x-k8s.io/v1beta1
+    kind: Cluster
+    metadata:
+      annotations: {}
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME
+    spec:
+      clusterNetwork:
+        pods:
+          cidrBlocks:
+            - 172.16.0.0/13
+        serviceDomain: cluster.local
+        services:
+          cidrBlocks:
+            - 172.24.0.0/13
+      controlPlaneRef:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlane
+        name: RELEASE-NAME-control-plane
+        namespace: NAMESPACE
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: OpenStackCluster
+        name: RELEASE-NAME
+        namespace: NAMESPACE
+  29: |
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    metadata:
+      annotations:
+        helm.sh/resource-policy: keep
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: control-plane
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-control-plane
+    spec:
+      kubeadmConfigSpec:
+        clusterConfiguration:
+          apiServer:
+            extraArgs:
+              admission-control-config-file: /etc/kubernetes/admission/configuration.yaml
+              v: "2"
+            extraVolumes:
+              - hostPath: /etc/kubernetes/admission
+                mountPath: /etc/kubernetes/admission
+                name: admission-configuration
+                pathType: Directory
+                readOnly: true
+          controllerManager:
+            extraArgs:
+              bind-address: 0.0.0.0
+              cloud-provider: external
+          etcd:
+            local:
+              dataDir: /var/lib/etcd
+              extraArgs:
+                election-timeout: "5000"
+                heartbeat-interval: "500"
+                listen-metrics-urls: http://0.0.0.0:2381
+                quota-backend-bytes: "4294967296"
+          scheduler:
+            extraArgs:
+              bind-address: 0.0.0.0
+        files:
+          - contentFrom:
+              secret:
+                key: admission-configuration.yaml
+                name: RELEASE-NAME-admission-configuration
+            owner: root:root
+            path: /etc/kubernetes/admission/configuration.yaml
+            permissions: "0644"
+          - content: |
+              # This file is created by the capi-helm-chart to ensure that its parent directory exists
+            owner: root:root
+            path: /etc/containerd/conf.d/.keepdir
+            permissions: "0644"
+          - content: |
+              # This file is created by the capi-helm-chart to ensure that its parent directory exists
+            owner: root:root
+            path: /etc/containerd/certs.d/.keepdir
+            permissions: "0644"
+          - content: |
+              server = "https://registry-1.docker.io"
+              [host."https://quay.io/v2/azimuth/docker.io"]
+              capabilities = ["pull", "resolve"]
+              skip_verify = false
+              override_path = true
+            owner: root:root
+            path: /etc/containerd/certs.d/docker.io/hosts.toml
+            permissions: "0644"
+          - content: |
+              server = "https://ghcr.io"
+              [host."https://quay.io/v2/azimuth/ghcr.io"]
+              capabilities = ["pull", "resolve"]
+              skip_verify = false
+              override_path = true
+            owner: root:root
+            path: /etc/containerd/certs.d/ghcr.io/hosts.toml
+            permissions: "0644"
+          - content: |
+              server = "https://nvcr.io"
+              [host."https://quay.io/v2/azimuth/nvcr.io"]
+              capabilities = ["pull", "resolve"]
+              skip_verify = false
+              override_path = true
+            owner: root:root
+            path: /etc/containerd/certs.d/nvcr.io/hosts.toml
+            permissions: "0644"
+          - content: |
+              server = "https://quay.io"
+              [host."https://quay.io/v2/azimuth/quay.io"]
+              capabilities = ["pull", "resolve"]
+              skip_verify = false
+              override_path = true
+            owner: root:root
+            path: /etc/containerd/certs.d/quay.io/hosts.toml
+            permissions: "0644"
+          - content: |
+              server = "https://registry.k8s.io"
+              [host."https://quay.io/v2/azimuth/registry.k8s.io"]
+              capabilities = ["pull", "resolve"]
+              skip_verify = false
+              override_path = true
+            owner: root:root
+            path: /etc/containerd/certs.d/registry.k8s.io/hosts.toml
+            permissions: "0644"
+          - content: |
+              ---
+              apiVersion: kubeproxy.config.k8s.io/v1alpha1
+              kind: KubeProxyConfiguration
+              metricsBindAddress: 0.0.0.0:10249
+            owner: root:root
+            path: /run/kubeadm/kube-proxy-configuration.yaml
+            permissions: "0644"
+        initConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+              cloud-provider: external
+            name: '{{ local_hostname }}'
+        joinConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+              cloud-provider: external
+            name: '{{ local_hostname }}'
+        preKubeadmCommands:
+          - |-
+            /usr/bin/bash -s <<EOF
+            grep -q '\[plugins."io.containerd.grpc.v1.cri".registry\]' /etc/containerd/config.toml && exit
+            cat <<CONTENT >> /etc/containerd/config.toml
+            [plugins."io.containerd.grpc.v1.cri".registry]
+              config_path = "/etc/containerd/certs.d"
+            CONTENT
+            systemctl restart containerd
+            EOF
+          - cat /run/kubeadm/kube-proxy-configuration.yaml >> /run/kubeadm/kubeadm.yaml
+      machineTemplate:
+        infrastructureRef:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+          kind: OpenStackMachineTemplate
+          name: RELEASE-NAME-control-plane-e39a716c
+          namespace: NAMESPACE
+        metadata:
+          labels:
+            capi.stackhpc.com/cluster: RELEASE-NAME
+            capi.stackhpc.com/component: control-plane
+        nodeDeletionTimeout: 5m0s
+        nodeDrainTimeout: 5m0s
+        nodeVolumeDetachTimeout: 5m0s
+      remediationStrategy:
+        maxRetry: 3
+        minHealthyPeriod: 1h
+        retryPeriod: 20m
+      replicas: 3
+      rolloutStrategy:
+        rollingUpdate:
+          maxSurge: 1
+        type: RollingUpdate
+      version: v1.29.2
+  30: |
+    apiVersion: cluster.x-k8s.io/v1beta1
+    kind: MachineHealthCheck
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: control-plane
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-control-plane
+    spec:
+      clusterName: RELEASE-NAME
+      maxUnhealthy: 1
+      nodeStartupTimeout: 30m0s
+      selector:
+        matchLabels:
+          capi.stackhpc.com/cluster: RELEASE-NAME
+          capi.stackhpc.com/component: control-plane
+      unhealthyConditions:
+        - status: Unknown
+          timeout: 5m0s
+          type: Ready
+        - status: "False"
+          timeout: 5m0s
+          type: Ready
+  31: |
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: OpenStackMachineTemplate
+    metadata:
+      annotations:
+        capi.stackhpc.com/template-checksum: e39a716cdf1bf13ae070b43ebb6355fe88befcac4f72eedfcc3cfff10f0eabab
+        helm.sh/resource-policy: keep
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: control-plane
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-control-plane-e39a716c
+    spec:
+      template:
+        spec:
+          flavor: vm.small
+          identityRef:
+            cloudName: openstack
+            name: RELEASE-NAME-cloud-credentials
+          image:
+            filter:
+              name: ubuntu-jammy-kube-v1.29.2
+  32: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: admission-configuration
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-admission-configuration
+    stringData:
+      admission-configuration.yaml: |
+        apiVersion: apiserver.config.k8s.io/v1
+        kind: AdmissionConfiguration
+        plugins: []
+  33: |
+    apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+    kind: KubeadmConfigTemplate
+    metadata:
+      annotations:
+        capi.stackhpc.com/template-checksum: d43bd1bb079c9f949f46b9f6bf89e1e1027a45756426801398f5ab1199a331c4
+        helm.sh/resource-policy: keep
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: worker
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        capi.stackhpc.com/node-group: group-1
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-group-1-d43bd1bb
+    spec:
+      template:
+        spec:
+          files:
+            - content: |
+                # This file is created by the capi-helm-chart to ensure that its parent directory exists
+              owner: root:root
+              path: /etc/containerd/conf.d/.keepdir
+              permissions: "0644"
+            - content: |
+                # This file is created by the capi-helm-chart to ensure that its parent directory exists
+              owner: root:root
+              path: /etc/containerd/certs.d/.keepdir
+              permissions: "0644"
+            - content: |
+                server = "https://registry-1.docker.io"
+                [host."https://quay.io/v2/azimuth/docker.io"]
+                capabilities = ["pull", "resolve"]
+                skip_verify = false
+                override_path = true
+              owner: root:root
+              path: /etc/containerd/certs.d/docker.io/hosts.toml
+              permissions: "0644"
+            - content: |
+                server = "https://ghcr.io"
+                [host."https://quay.io/v2/azimuth/ghcr.io"]
+                capabilities = ["pull", "resolve"]
+                skip_verify = false
+                override_path = true
+              owner: root:root
+              path: /etc/containerd/certs.d/ghcr.io/hosts.toml
+              permissions: "0644"
+            - content: |
+                server = "https://nvcr.io"
+                [host."https://quay.io/v2/azimuth/nvcr.io"]
+                capabilities = ["pull", "resolve"]
+                skip_verify = false
+                override_path = true
+              owner: root:root
+              path: /etc/containerd/certs.d/nvcr.io/hosts.toml
+              permissions: "0644"
+            - content: |
+                server = "https://quay.io"
+                [host."https://quay.io/v2/azimuth/quay.io"]
+                capabilities = ["pull", "resolve"]
+                skip_verify = false
+                override_path = true
+              owner: root:root
+              path: /etc/containerd/certs.d/quay.io/hosts.toml
+              permissions: "0644"
+            - content: |
+                server = "https://registry.k8s.io"
+                [host."https://quay.io/v2/azimuth/registry.k8s.io"]
+                capabilities = ["pull", "resolve"]
+                skip_verify = false
+                override_path = true
+              owner: root:root
+              path: /etc/containerd/certs.d/registry.k8s.io/hosts.toml
+              permissions: "0644"
+          joinConfiguration:
+            nodeRegistration:
+              kubeletExtraArgs:
+                cloud-provider: external
+                node-labels: capi.stackhpc.com/node-group=group-1
+              name: '{{ local_hostname }}'
+          preKubeadmCommands:
+            - |-
+              /usr/bin/bash -s <<EOF
+              grep -q '\[plugins."io.containerd.grpc.v1.cri".registry\]' /etc/containerd/config.toml && exit
+              cat <<CONTENT >> /etc/containerd/config.toml
+              [plugins."io.containerd.grpc.v1.cri".registry]
+                config_path = "/etc/containerd/certs.d"
+              CONTENT
+              systemctl restart containerd
+              EOF
+  34: |
+    apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+    kind: KubeadmConfigTemplate
+    metadata:
+      annotations:
+        capi.stackhpc.com/template-checksum: e1d1a382f8640c6551c40f3da6902e8d45a774e09fe30be4898ba00a70a63a67
+        helm.sh/resource-policy: keep
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: worker
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        capi.stackhpc.com/node-group: group-2
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-group-2-e1d1a382
+    spec:
+      template:
+        spec:
+          files:
+            - content: |
+                # This file is created by the capi-helm-chart to ensure that its parent directory exists
+              owner: root:root
+              path: /etc/containerd/conf.d/.keepdir
+              permissions: "0644"
+            - content: |
+                # This file is created by the capi-helm-chart to ensure that its parent directory exists
+              owner: root:root
+              path: /etc/containerd/certs.d/.keepdir
+              permissions: "0644"
+            - content: |
+                server = "https://registry-1.docker.io"
+                [host."https://quay.io/v2/azimuth/docker.io"]
+                capabilities = ["pull", "resolve"]
+                skip_verify = false
+                override_path = true
+              owner: root:root
+              path: /etc/containerd/certs.d/docker.io/hosts.toml
+              permissions: "0644"
+            - content: |
+                server = "https://ghcr.io"
+                [host."https://quay.io/v2/azimuth/ghcr.io"]
+                capabilities = ["pull", "resolve"]
+                skip_verify = false
+                override_path = true
+              owner: root:root
+              path: /etc/containerd/certs.d/ghcr.io/hosts.toml
+              permissions: "0644"
+            - content: |
+                server = "https://nvcr.io"
+                [host."https://quay.io/v2/azimuth/nvcr.io"]
+                capabilities = ["pull", "resolve"]
+                skip_verify = false
+                override_path = true
+              owner: root:root
+              path: /etc/containerd/certs.d/nvcr.io/hosts.toml
+              permissions: "0644"
+            - content: |
+                server = "https://quay.io"
+                [host."https://quay.io/v2/azimuth/quay.io"]
+                capabilities = ["pull", "resolve"]
+                skip_verify = false
+                override_path = true
+              owner: root:root
+              path: /etc/containerd/certs.d/quay.io/hosts.toml
+              permissions: "0644"
+            - content: |
+                server = "https://registry.k8s.io"
+                [host."https://quay.io/v2/azimuth/registry.k8s.io"]
+                capabilities = ["pull", "resolve"]
+                skip_verify = false
+                override_path = true
+              owner: root:root
+              path: /etc/containerd/certs.d/registry.k8s.io/hosts.toml
+              permissions: "0644"
+          joinConfiguration:
+            nodeRegistration:
+              kubeletExtraArgs:
+                cloud-provider: external
+                node-labels: capi.stackhpc.com/node-group=group-2
+              name: '{{ local_hostname }}'
+          preKubeadmCommands:
+            - |-
+              /usr/bin/bash -s <<EOF
+              grep -q '\[plugins."io.containerd.grpc.v1.cri".registry\]' /etc/containerd/config.toml && exit
+              cat <<CONTENT >> /etc/containerd/config.toml
+              [plugins."io.containerd.grpc.v1.cri".registry]
+                config_path = "/etc/containerd/certs.d"
+              CONTENT
+              systemctl restart containerd
+              EOF
+  35: |
+    apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+    kind: KubeadmConfigTemplate
+    metadata:
+      annotations:
+        capi.stackhpc.com/template-checksum: 5ff6f8cd8d78686d5c3ab32f5ed8fa82b82bf5feea7452c6466b5e9173e799e3
+        helm.sh/resource-policy: keep
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: worker
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        capi.stackhpc.com/node-group: group-3
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-group-3-5ff6f8cd
+    spec:
+      template:
+        spec:
+          files:
+            - content: |
+                # This file is created by the capi-helm-chart to ensure that its parent directory exists
+              owner: root:root
+              path: /etc/containerd/conf.d/.keepdir
+              permissions: "0644"
+            - content: |
+                # This file is created by the capi-helm-chart to ensure that its parent directory exists
+              owner: root:root
+              path: /etc/containerd/certs.d/.keepdir
+              permissions: "0644"
+            - content: |
+                server = "https://registry-1.docker.io"
+                [host."https://quay.io/v2/azimuth/docker.io"]
+                capabilities = ["pull", "resolve"]
+                skip_verify = false
+                override_path = true
+              owner: root:root
+              path: /etc/containerd/certs.d/docker.io/hosts.toml
+              permissions: "0644"
+            - content: |
+                server = "https://ghcr.io"
+                [host."https://quay.io/v2/azimuth/ghcr.io"]
+                capabilities = ["pull", "resolve"]
+                skip_verify = false
+                override_path = true
+              owner: root:root
+              path: /etc/containerd/certs.d/ghcr.io/hosts.toml
+              permissions: "0644"
+            - content: |
+                server = "https://nvcr.io"
+                [host."https://quay.io/v2/azimuth/nvcr.io"]
+                capabilities = ["pull", "resolve"]
+                skip_verify = false
+                override_path = true
+              owner: root:root
+              path: /etc/containerd/certs.d/nvcr.io/hosts.toml
+              permissions: "0644"
+            - content: |
+                server = "https://quay.io"
+                [host."https://quay.io/v2/azimuth/quay.io"]
+                capabilities = ["pull", "resolve"]
+                skip_verify = false
+                override_path = true
+              owner: root:root
+              path: /etc/containerd/certs.d/quay.io/hosts.toml
+              permissions: "0644"
+            - content: |
+                server = "https://registry.k8s.io"
+                [host."https://quay.io/v2/azimuth/registry.k8s.io"]
+                capabilities = ["pull", "resolve"]
+                skip_verify = false
+                override_path = true
+              owner: root:root
+              path: /etc/containerd/certs.d/registry.k8s.io/hosts.toml
+              permissions: "0644"
+          joinConfiguration:
+            nodeRegistration:
+              kubeletExtraArgs:
+                cloud-provider: external
+                node-labels: capi.stackhpc.com/node-group=group-3
+              name: '{{ local_hostname }}'
+          preKubeadmCommands:
+            - |-
+              /usr/bin/bash -s <<EOF
+              grep -q '\[plugins."io.containerd.grpc.v1.cri".registry\]' /etc/containerd/config.toml && exit
+              cat <<CONTENT >> /etc/containerd/config.toml
+              [plugins."io.containerd.grpc.v1.cri".registry]
+                config_path = "/etc/containerd/certs.d"
+              CONTENT
+              systemctl restart containerd
+              EOF
+  36: |
+    apiVersion: cluster.x-k8s.io/v1beta1
+    kind: MachineDeployment
+    metadata:
+      annotations: null
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: worker
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        capi.stackhpc.com/node-group: group-1
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-group-1
+    spec:
+      clusterName: RELEASE-NAME
+      replicas: 1
+      selector:
+        matchLabels:
+          capi.stackhpc.com/cluster: RELEASE-NAME
+          capi.stackhpc.com/component: worker
+          capi.stackhpc.com/node-group: group-1
+          cluster.x-k8s.io/cluster-name: RELEASE-NAME
+      strategy:
+        rollingUpdate:
+          deletePolicy: Random
+          maxSurge: 0
+          maxUnavailable: 1
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            capi.stackhpc.com/cluster: RELEASE-NAME
+            capi.stackhpc.com/component: worker
+            capi.stackhpc.com/node-group: group-1
+        spec:
+          bootstrap:
+            configRef:
+              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+              kind: KubeadmConfigTemplate
+              name: RELEASE-NAME-group-1-d43bd1bb
+          clusterName: RELEASE-NAME
+          infrastructureRef:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: OpenStackMachineTemplate
+            name: RELEASE-NAME-group-1-974c4cfd
+          nodeDeletionTimeout: 5m0s
+          nodeDrainTimeout: 5m0s
+          nodeVolumeDetachTimeout: 5m0s
+          version: v1.29.2
+  37: |
+    apiVersion: cluster.x-k8s.io/v1beta1
+    kind: MachineDeployment
+    metadata:
+      annotations:
+        cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "3"
+        cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "1"
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: worker
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        capi.stackhpc.com/node-group: group-2
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-group-2
+    spec:
+      clusterName: RELEASE-NAME
+      selector:
+        matchLabels:
+          capi.stackhpc.com/cluster: RELEASE-NAME
+          capi.stackhpc.com/component: worker
+          capi.stackhpc.com/node-group: group-2
+          cluster.x-k8s.io/cluster-name: RELEASE-NAME
+      strategy:
+        rollingUpdate:
+          deletePolicy: Random
+          maxSurge: 0
+          maxUnavailable: 1
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            capi.stackhpc.com/cluster: RELEASE-NAME
+            capi.stackhpc.com/component: worker
+            capi.stackhpc.com/node-group: group-2
+        spec:
+          bootstrap:
+            configRef:
+              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+              kind: KubeadmConfigTemplate
+              name: RELEASE-NAME-group-2-e1d1a382
+          clusterName: RELEASE-NAME
+          infrastructureRef:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: OpenStackMachineTemplate
+            name: RELEASE-NAME-group-2-26685203
+          nodeDeletionTimeout: 5m0s
+          nodeDrainTimeout: 5m0s
+          nodeVolumeDetachTimeout: 5m0s
+          version: v1.29.2
+  38: |
+    apiVersion: cluster.x-k8s.io/v1beta1
+    kind: MachineDeployment
+    metadata:
+      annotations:
+        cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "5"
+        cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "0"
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: worker
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        capi.stackhpc.com/node-group: group-3
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-group-3
+    spec:
+      clusterName: RELEASE-NAME
+      selector:
+        matchLabels:
+          capi.stackhpc.com/cluster: RELEASE-NAME
+          capi.stackhpc.com/component: worker
+          capi.stackhpc.com/node-group: group-3
+          cluster.x-k8s.io/cluster-name: RELEASE-NAME
+      strategy:
+        rollingUpdate:
+          deletePolicy: Random
+          maxSurge: 0
+          maxUnavailable: 1
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            capi.stackhpc.com/cluster: RELEASE-NAME
+            capi.stackhpc.com/component: worker
+            capi.stackhpc.com/node-group: group-3
+        spec:
+          bootstrap:
+            configRef:
+              apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+              kind: KubeadmConfigTemplate
+              name: RELEASE-NAME-group-3-5ff6f8cd
+          clusterName: RELEASE-NAME
+          infrastructureRef:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: OpenStackMachineTemplate
+            name: RELEASE-NAME-group-3-26685203
+          nodeDeletionTimeout: 5m0s
+          nodeDrainTimeout: 5m0s
+          nodeVolumeDetachTimeout: 5m0s
+          version: v1.29.2
+  39: |
+    apiVersion: cluster.x-k8s.io/v1beta1
+    kind: MachineHealthCheck
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: worker
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        capi.stackhpc.com/node-group: group-1
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-group-1
+    spec:
+      clusterName: RELEASE-NAME
+      maxUnhealthy: 100%
+      nodeStartupTimeout: 30m0s
+      selector:
+        matchLabels:
+          capi.stackhpc.com/cluster: RELEASE-NAME
+          capi.stackhpc.com/component: worker
+          capi.stackhpc.com/node-group: group-1
+      unhealthyConditions:
+        - status: Unknown
+          timeout: 5m0s
+          type: Ready
+        - status: "False"
+          timeout: 5m0s
+          type: Ready
+  40: |
+    apiVersion: cluster.x-k8s.io/v1beta1
+    kind: MachineHealthCheck
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: worker
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        capi.stackhpc.com/node-group: group-2
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-group-2
+    spec:
+      clusterName: RELEASE-NAME
+      maxUnhealthy: 100%
+      nodeStartupTimeout: 30m0s
+      selector:
+        matchLabels:
+          capi.stackhpc.com/cluster: RELEASE-NAME
+          capi.stackhpc.com/component: worker
+          capi.stackhpc.com/node-group: group-2
+      unhealthyConditions:
+        - status: Unknown
+          timeout: 5m0s
+          type: Ready
+        - status: "False"
+          timeout: 5m0s
+          type: Ready
+  41: |
+    apiVersion: cluster.x-k8s.io/v1beta1
+    kind: MachineHealthCheck
+    metadata:
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: worker
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        capi.stackhpc.com/node-group: group-3
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-group-3
+    spec:
+      clusterName: RELEASE-NAME
+      maxUnhealthy: 100%
+      nodeStartupTimeout: 30m0s
+      selector:
+        matchLabels:
+          capi.stackhpc.com/cluster: RELEASE-NAME
+          capi.stackhpc.com/component: worker
+          capi.stackhpc.com/node-group: group-3
+      unhealthyConditions:
+        - status: Unknown
+          timeout: 5m0s
+          type: Ready
+        - status: "False"
+          timeout: 5m0s
+          type: Ready
+  42: |
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: OpenStackMachineTemplate
+    metadata:
+      annotations:
+        capi.stackhpc.com/template-checksum: 974c4cfd217a218b8577c9b1362980b997329854003b0b8d126a018fb0429b61
+        helm.sh/resource-policy: keep
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: worker
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        capi.stackhpc.com/node-group: group-1
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-group-1-974c4cfd
+    spec:
+      template:
+        spec:
+          flavor: vm.small
+          identityRef:
+            cloudName: openstack
+            name: RELEASE-NAME-cloud-credentials
+          image:
+            filter:
+              name: ubuntu-jammy-kube-v1.29.2
+  43: |
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: OpenStackMachineTemplate
+    metadata:
+      annotations:
+        capi.stackhpc.com/template-checksum: 2668520359b6b0cda12be8a8a3bfeafa8e9d6866f2f3122b08e9755eb30c0d1c
+        helm.sh/resource-policy: keep
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: worker
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        capi.stackhpc.com/node-group: group-2
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-group-2-26685203
+    spec:
+      template:
+        spec:
+          flavor: vm.large
+          identityRef:
+            cloudName: openstack
+            name: RELEASE-NAME-cloud-credentials
+          image:
+            filter:
+              name: ubuntu-jammy-kube-v1.29.2
+  44: |
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: OpenStackMachineTemplate
+    metadata:
+      annotations:
+        capi.stackhpc.com/template-checksum: 2668520359b6b0cda12be8a8a3bfeafa8e9d6866f2f3122b08e9755eb30c0d1c
+        helm.sh/resource-policy: keep
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: worker
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        capi.stackhpc.com/node-group: group-3
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-group-3-26685203
+    spec:
+      template:
+        spec:
+          flavor: vm.large
+          identityRef:
+            cloudName: openstack
+            name: RELEASE-NAME-cloud-credentials
+          image:
+            filter:
+              name: ubuntu-jammy-kube-v1.29.2
+  45: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      annotations:
+        helm.sh/resource-policy: keep
+      labels:
+        capi.stackhpc.com/cluster: RELEASE-NAME
+        capi.stackhpc.com/component: cloud-credentials
+        capi.stackhpc.com/infrastructure-provider: openstack
+        capi.stackhpc.com/managed-by: Helm
+        helm.sh/chart: openstack-cluster-0.1.0
+      name: RELEASE-NAME-cloud-credentials
+    stringData:
+      clouds.yaml: |
+        clouds:
+          openstack:
+            auth:
+              application_credential_id: <app cred id>
+              application_credential_secret: <app cred secret>
+              auth_url: https://my.cloud:5000
+            auth_type: v3applicationcredential
+            identity_api_version: 3
+            interface: public
+            region_name: RegionOne

--- a/charts/openstack-cluster/tests/snapshot_ovn_test.yaml
+++ b/charts/openstack-cluster/tests/snapshot_ovn_test.yaml
@@ -1,0 +1,10 @@
+# To update manifest snapshots run helm unittest plugin with -u option:
+# docker run -i --rm -v $(pwd):/apps helmunittest/helm-unittest -u charts/openstack-cluster
+suite: Manifest snapshot tests
+values:
+  - values_base.yaml
+  - values_ovn.yaml
+tests:
+  - it: templated manifests should match snapshot
+    asserts:
+      - matchSnapshot: {}

--- a/charts/openstack-cluster/tests/values_ovn.yaml
+++ b/charts/openstack-cluster/tests/values_ovn.yaml
@@ -1,0 +1,35 @@
+---
+apiServer:
+  loadBalancerProvider: ovn
+
+clusterNetworking:
+  workerNodeSecurityGroupRules:
+  - name: Worker nodePort TCP
+    remoteIPPrefix: 0.0.0.0/0
+    protocol: tcp
+    direction: ingress
+    etherType: IPv4
+    portRangeMin: 30000
+    portRangeMax: 32767
+  - name: Worker nodePort TCP2
+    remoteIPPrefix: 0.0.0.0/0
+    protocol: tcp
+    direction: ingress
+    etherType: IPv4
+    portRangeMin: 30001
+    portRangeMax: 32767
+
+nodeGroups:
+  - name: group-1
+    machineFlavor: vm.small
+    machineCount: 1
+  - name: group-2
+    machineFlavor: vm.large
+    machineCountMin: 1
+    machineCountMax: 3
+    autoscale: true
+  - name: group-3
+    machineFlavor: vm.large
+    machineCountMin: 0
+    machineCountMax: 5
+    autoscale: true

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -83,6 +83,10 @@ clusterNetworking:
   # Indicates if the managed security groups should allow all in-cluster traffic
   # The default CNI installed by the addons is Cilium, so this is true by default
   allowAllInClusterTraffic: true
+  # Defines the rules that should be applied to worker nodes.
+  workerNodeSecurityGroupRules: []
+  # Defines the rules that should be applied to control plane nodes.
+  controlPlaneNodesSecurityGroupRules: []
   # The ID of the external network to use
   # If not given, the external network will be detected
   externalNetworkId:


### PR DESCRIPTION
Since CAPO v0.11.0 security groups prevent traffic originating from outside of the cluster network from reaching NodePorts [1]. This caused a regression in the expected behaviour on clouds that were using the OVN Octavia loadbalancer provider [2].

To work around this regression, since CAPO v0.12.0 it is possible to set workerNodeSecurityGroupRules and controlPlaneNodesSecurityGroupRules, containing a list of security group rules that should be applied to worker and control-plane nodes respectively [3].

Set workerNodeSecurityGroupRules when apiServer.loadBalancerProvider=ovn, and expose worker and control-plane security groups in values.yaml.

[1] https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2128
[2] https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/2333
[3] https://github.com/kubernetes-sigs/cluster-api-provider-openstack/pull/2353