### PR TITLE
Fix broken invocation of helm-unittest

### DIFF
--- a/.github/workflows/update-addons.yml
+++ b/.github/workflows/update-addons.yml
@@ -172,10 +172,11 @@ jobs:
       - name: Update manifest snapshots
         run: |-
           helm dependency update charts/openstack-cluster && \
-            docker run -i --rm --user $(id -u) \
+            docker run -i --rm \
             -v $(pwd):/apps \
             helmunittest/helm-unittest -u \
-            charts/openstack-cluster
+            charts/openstack-cluster && \
+            chown -R ${USER}:${USER} charts
 
       - name: Generate app token for PR
         uses: azimuth-cloud/github-actions/generate-app-token@master

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -96,10 +96,11 @@ jobs:
       - name: Update manifest snapshots
         run: |-
           helm dependency update charts/openstack-cluster && \
-            docker run -i --rm --user $(id -u) \
+            docker run -i --rm \
             -v $(pwd):/apps \
             helmunittest/helm-unittest -u \
-            charts/openstack-cluster
+            charts/openstack-cluster && \
+            chown -R ${USER}:${USER} charts
 
       - name: Write Skopeo manifest
         if: ${{ matrix.key == 'sonobuoy' }}


### PR DESCRIPTION
Fixes issue where helm-unittest container was unable to create `/.cache`

> level=WARN msg="failed to load plugin (ignoring)" plugin_yaml=/usr/local/share/helm/plugins/unittest/plugin.yaml error="failed to create plugin manager: failed to create wazero compilation cache: create directory /.cache/helm/wazero-build: mkdir /.cache: permission denied"
Error: unknown command "unittest" for "helm"
