### PR TITLE
Correct typo in workerNodeSecurityGroupRules

### DIFF
--- a/charts/openstack-cluster/templates/_helpers.tpl
+++ b/charts/openstack-cluster/templates/_helpers.tpl
@@ -582,7 +582,7 @@ Return a list of security groups to apply to worker nodes when
 OVN is the apiserver loadbalancer provider
 */}}
 {{- define "openstack-cluster.workerNodesSecurityGroupRulesOVN" }}
-workerNodeSecurityGroupRules:
+workerNodesSecurityGroupRules:
   - name: Worker nodePort TCP
     remoteIPPrefix: 0.0.0.0/0
     protocol: tcp
@@ -607,8 +607,8 @@ Creates a list of security group rules to apply to worker nodes
 {{- $ovnapiserver := index . 1 }}
 {{- if $ovnapiserver }}
 {{- $ovn := include "openstack-cluster.workerNodesSecurityGroupRulesOVN" $ovnapiserver | fromYaml }}
-{{- concat $msecgroups.workerNodeSecurityGroupRules $ovn.workerNodeSecurityGroupRules | uniq | toYaml }}
+{{- concat $msecgroups.workerNodesSecurityGroupRules $ovn.workerNodesSecurityGroupRules | uniq | toYaml }}
 {{- else }}
-{{- toYaml $msecgroups.workerNodeSecurityGroupRules }}
+{{- toYaml $msecgroups.workerNodesSecurityGroupRules }}
 {{- end }}
 {{- end }}

--- a/charts/openstack-cluster/templates/cluster-openstack.yaml
+++ b/charts/openstack-cluster/templates/cluster-openstack.yaml
@@ -22,8 +22,8 @@ spec:
   {{- if .manageSecurityGroups }}
   managedSecurityGroups:
     allowAllInClusterTraffic: {{ .allowAllInClusterTraffic }}
-    {{- if or (eq $.Values.apiServer.loadBalancerProvider "ovn") .workerNodeSecurityGroupRules }}
-    workerNodeSecurityGroupRules: {{ include "openstack-cluster.workerNodesSecurityGroupRules" ( list . (eq $.Values.apiServer.loadBalancerProvider "ovn")) | nindent 6 }}
+    {{- if or (eq $.Values.apiServer.loadBalancerProvider "ovn") .workerNodesSecurityGroupRules }}
+    workerNodesSecurityGroupRules: {{ include "openstack-cluster.workerNodesSecurityGroupRules" ( list . (eq $.Values.apiServer.loadBalancerProvider "ovn")) | nindent 6 }}
     {{- end }}
     {{- if .controlPlaneNodesSecurityGroupRules }}
     controlPlaneNodesSecurityGroupRules: {{ .controlPlaneNodesSecurityGroupRules | nindent 6 }}

--- a/charts/openstack-cluster/tests/__snapshot__/snapshot_ovn_test.yaml.snap
+++ b/charts/openstack-cluster/tests/__snapshot__/snapshot_ovn_test.yaml.snap
@@ -744,7 +744,7 @@ templated manifests should match snapshot:
         name: RELEASE-NAME-cloud-credentials
       managedSecurityGroups:
         allowAllInClusterTraffic: true
-        workerNodeSecurityGroupRules:
+        workerNodesSecurityGroupRules:
           - direction: ingress
             etherType: IPv4
             name: Worker nodePort TCP

--- a/charts/openstack-cluster/tests/values_ovn.yaml
+++ b/charts/openstack-cluster/tests/values_ovn.yaml
@@ -3,7 +3,7 @@ apiServer:
   loadBalancerProvider: ovn
 
 clusterNetworking:
-  workerNodeSecurityGroupRules:
+  workerNodesSecurityGroupRules:
   - name: Worker nodePort TCP
     remoteIPPrefix: 0.0.0.0/0
     protocol: tcp

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -84,7 +84,7 @@ clusterNetworking:
   # The default CNI installed by the addons is Cilium, so this is true by default
   allowAllInClusterTraffic: true
   # Defines the rules that should be applied to worker nodes.
-  workerNodeSecurityGroupRules: []
+  workerNodesSecurityGroupRules: []
   # Defines the rules that should be applied to control plane nodes.
   controlPlaneNodesSecurityGroupRules: []
   # The ID of the external network to use


### PR DESCRIPTION
Per the Custom Resource definition, this spec item should be workerNodesSecurityGroupRules.