### PR TITLE
Add kured addon

### DIFF
--- a/.github/workflows/update-addons.yml
+++ b/.github/workflows/update-addons.yml
@@ -116,6 +116,9 @@ jobs:
           - key: reloader
             path: reloader.chart
 
+          - key: kured
+            path: kured.chart
+
     name: ${{ matrix.key }}
     steps:
       - name: Checkout

--- a/charts/cluster-addons/templates/kured.yaml
+++ b/charts/cluster-addons/templates/kured.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.kured.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cluster-addons.componentName" (list . "kured") }}-cfg
+  labels:
+    {{- include "cluster-addons.componentLabels" (list . "kured") | nindent 4 }}
+stringData:
+  values: |
+    {{- toYaml .Values.kured.release.values | nindent 4 }}
+---
+apiVersion: addons.stackhpc.com/v1alpha1
+kind: HelmRelease
+metadata:
+  name: {{ include "cluster-addons.componentName" (list . "kured") }}
+  labels: {{ include "cluster-addons.componentLabels" (list . "kured") | nindent 4 }}
+  annotations:
+    # Tell Argo to ignore the non-controller owner references for this object
+    argocd.argoproj.io/sync-options: "ControllerReferencesOnly=true"
+spec:
+  clusterName: {{ include "cluster-addons.clusterName" . }}
+  bootstrap: true
+  chart: {{ toYaml .Values.kured.chart | nindent 4 }}
+  targetNamespace: {{ .Values.kured.release.namespace }}
+  releaseName: kured
+  valuesSources:
+    - secret:
+        name: {{ include "cluster-addons.componentName" (list . "kured") }}-cfg
+        key: values
+{{- end }}

--- a/charts/cluster-addons/values.yaml
+++ b/charts/cluster-addons/values.yaml
@@ -194,6 +194,18 @@ reloader:
         # Restrict scope to namespace
         watchGlobally: false
 
+# Settings for kured, the Kubernetes Reboot Daemon
+kured:
+  # Indicates if kured should be enabled
+  enabled: false
+  chart:
+    repo: https://kubereboot.github.io/charts
+    name: kured
+    version: 6.1.0
+  release:
+    namespace: kube-system
+    values: {}
+
 # Settings for etcd defragmentation jobs
 etcdDefrag:
   # Indicates if the etcd defragmentation job should be enabled

--- a/skopeo-manifests/kured.yaml
+++ b/skopeo-manifests/kured.yaml
@@ -1,0 +1,4 @@
+ghcr.io:
+  images:
+    kubereboot/kured:
+    - 1.23.0


### PR DESCRIPTION
## Why?

When automatically upgrade is enabled on a node, a file called `/run/reboot-required` is created when needed. `kured` is able to schedule rollout reboots of nodes.

Security updates from critical components (such as kernel, glibc…) can be applied without recreating the nodes.

## Summary

- Add `kured` (Kubernetes Reboot Daemon) as a new cluster addon
- Chart: `kubereboot/kured` v6.1.0 from `https://kubereboot.github.io/charts`
- Deployed to `kube-system`, disabled by default
- Add `skopeo-manifests/kured.yaml` for image mirroring (`ghcr.io/kubereboot/kured:1.23.0`)
- Add matrix entry in `update-addons.yml` for automatic version bumps

## Test plan

- [ ] `helm lint charts/cluster-addons/`
- [ ] `helm template test charts/cluster-addons/ --set kured.enabled=true | grep -A5 "releaseName: kured"`