### PR TITLE
Expose KCP certificatesExpiryDays in the openstack-cluster chart

### DIFF
--- a/charts/openstack-cluster/templates/control-plane/kubeadm-control-plane.yaml
+++ b/charts/openstack-cluster/templates/control-plane/kubeadm-control-plane.yaml
@@ -179,6 +179,10 @@ spec:
   replicas: {{ .Values.controlPlane.machineCount }}
   remediationStrategy: {{ toYaml .Values.controlPlane.remediationStrategy | nindent 4 }}
   rolloutStrategy: {{ toYaml .Values.controlPlane.rolloutStrategy | nindent 4 }}
+   {{- if gt (.Values.controlPlane.certificatesExpiryDays | int) 0 }}
+  rolloutBefore:
+    certificatesExpiryDays: {{ .Values.controlPlane.certificatesExpiryDays | int }}
+  {{- end }}
   machineTemplate:
     metadata:
       labels: {{ include "openstack-cluster.componentSelectorLabels" (list . "control-plane") | nindent 8 }}

--- a/charts/openstack-cluster/values.schema.json
+++ b/charts/openstack-cluster/values.schema.json
@@ -3210,6 +3210,16 @@
           "additionalProperties": false,
           "required": []
         },
+        "certificatesExpiryDays": {
+          "description": "Roll out control plane Machines before their kubeadm-managed certificates expire. If unset, certificate-expiry based rollout is disabled.",
+          "minimum": 7,
+          "required": [],
+          "title": "certificatesExpiryDays",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "serverGroupId": {
           "default": "",
           "description": "The ID of the server group to use for control plane machines",

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -741,6 +741,10 @@ controlPlane:
   # https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/controlplane.cluster.x-k8s.io/kubeadmcontrolplane_v1beta1.json#/properties/spec/properties/kubeadmConfigSpec
   # because we've augmented that schema with an additional kubeProxyConfiguration field
 
+  # Roll out control plane machines before their certificates expire.
+  # If unset, Cluster API does not trigger rollouts based on certificate expiry.
+  # See https://cluster-api.sigs.k8s.io/tasks/certs/auto-rotate-certificates-in-kcp/
+  certificatesExpiryDays:
   # The kubeadm config specification for the control plane
   # By default, this uses a simple configuration that enables the external cloud provider
   # @schema


### PR DESCRIPTION
## Summary

Expose the KubeadmControlPlane `rolloutBefore.certificatesExpiryDays` option through the `openstack-cluster` Helm chart.

This allows deployments to opt in to Cluster API's automatic control plane rollout before kubeadm-managed certificates expire.

- related CAPI handbook: https://cluster-api.sigs.k8s.io/tasks/certs/auto-rotate-certificates-in-kcp

## Motivation

By default, kubeadm generated control plane certificates expire after one year. If a workload cluster is not upgraded before then, certificate expiry can lead to cluster disruption and manual recovery.

Cluster API has supported this rollout mechanism for some time, but it has not previously been exposed through the Azimuth Helm charts. This change makes the existing upstream capability available without changing the default behaviour.

This change exposes that field so deployments can enable automatic certificate-driven rollouts when appropriate.

## Notes

- The value is optional and unset by default.
- Existing behaviour is unchanged unless the value is explicitly configured.
- This change only exposes existing Cluster API functionality; it does not change the rollout logic itself.
- This wiki is describing why this PR is needed: https://wiki.stackhpc.com/doc/azimuth-automatic-certificate-rotation-in-cluster-api-iEH8Cy8HHH