### PR TITLE
Test OpenStackCluster and OpenStackMachine with kubeconform

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -68,7 +68,7 @@ jobs:
             --strict --summary \
             --schema-location default \
             --schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
-            --skip HelmRelease,Manifests,OpenStackCluster,OpenStackMachineTemplate
+            --skip HelmRelease,Manifests
 
       # NOTE: Run the following command locally to generate updated snapshots:
       # docker run -i --rm -v $(pwd):/apps helmunittest/helm-unittest charts/openstack-cluster -u


### PR DESCRIPTION
Since [1] OpenStackCluster and OpenStackMachine schemas are available from the default kubeconform repositories, so we can stop excluding these resources from the conformity tests.

[1] https://github.com/datreeio/CRDs-catalog/pull/907