### PR TITLE
Stop testing Kubernetes 1.33 in CI

### DIFF
--- a/.github/workflows/ensure-capi-images.yaml
+++ b/.github/workflows/ensure-capi-images.yaml
@@ -7,10 +7,6 @@ on:
         description: The Git ref under test.
         required: true
     outputs:
-      kube-1-33-image:
-        value: ${{ jobs.produce_outputs.outputs.kube-1-33-image }}
-      kube-1-33-version:
-        value: ${{ jobs.produce_outputs.outputs.kube-1-33-version }}
       kube-1-34-image:
         value: ${{ jobs.produce_outputs.outputs.kube-1-34-image }}
       kube-1-34-version:
@@ -49,9 +45,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: kube-1-33
-            image: ${{ fromJSON(needs.image_manifest.outputs.manifest).kubernetes-1-33-jammy }}
-            skip: ${{ github.event.pull_request.draft }}
           - name: kube-1-34
             image: ${{ fromJSON(needs.image_manifest.outputs.manifest).kubernetes-1-34-jammy }}
             skip: false
@@ -122,8 +115,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ensure_image]
     outputs:
-      kube-1-33-image: ${{ fromJSON(steps.matrix-outputs.outputs.result).image-id.kube-1-33 }}
-      kube-1-33-version: ${{ fromJSON(steps.matrix-outputs.outputs.result).kube-version.kube-1-33 }}
       kube-1-34-image: ${{ fromJSON(steps.matrix-outputs.outputs.result).image-id.kube-1-34 }}
       kube-1-34-version: ${{ fromJSON(steps.matrix-outputs.outputs.result).kube-version.kube-1-34 }}
       kube-1-35-image: ${{ fromJSON(steps.matrix-outputs.outputs.result).image-id.kube-1-35 }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -282,17 +282,6 @@ jobs:
         timeout-minutes: 180
         if: ${{ vars.TARGET_CLOUD == 'arcus' }}
  
-      - name: Upgrade to Kubernetes 1.33
-        uses: ./.github/actions/upgrade-and-test
-        with:
-          name: ci-${{ github.run_id }}-${{ github.job }}
-          os-cloud: ${{ vars.TARGET_CLOUD }}
-          chart-version: ${{ inputs.chart-version }}
-          kubernetes-version: ${{ fromJson(inputs.images).kube-1-33-version }}
-          image-id: ${{ fromJson(inputs.images).kube-1-33-image }}
-          defaults-path: ./.github/values/${{ vars.TARGET_CLOUD }}/base.yaml
-          overrides-path: ./.github/values/${{ vars.TARGET_CLOUD }}/kube-upgrade.yaml
-
       - name: Upgrade to Kubernetes 1.34
         uses: ./.github/actions/upgrade-and-test
         with:


### PR DESCRIPTION
Kubernetes 1.33 is EOL.