### PR TITLE
Fix broken dependency update CI

### DIFF
--- a/.github/workflows/update-addons.yml
+++ b/.github/workflows/update-addons.yml
@@ -183,11 +183,10 @@ jobs:
       - name: Update manifest snapshots
         run: |-
           helm dependency update charts/openstack-cluster && \
-            docker run -i --rm \
+            docker run -i --rm --user $(id -u) \
             -v $(pwd):/apps \
             helmunittest/helm-unittest -u \
-            charts/openstack-cluster && \
-            chown -R ${USER}:${USER} charts
+            charts/openstack-cluster
 
       - name: Generate app token for PR
         uses: azimuth-cloud/github-actions/generate-app-token@master

--- a/.github/workflows/update-addons.yml
+++ b/.github/workflows/update-addons.yml
@@ -82,7 +82,7 @@ jobs:
                 enabled: false
 
           - key: amd-gpu-operator
-            path: amdGPUOperator
+            path: amdGPUOperator.chart
             values: |
               node-feature-discovery:
                 enabled: false

--- a/.github/workflows/update-addons.yml
+++ b/.github/workflows/update-addons.yml
@@ -185,6 +185,7 @@ jobs:
           helm dependency update charts/openstack-cluster && \
             docker run -i --rm --user $(id -u) \
             -v $(pwd):/apps \
+            --tmpfs /.cache \
             helmunittest/helm-unittest -u \
             charts/openstack-cluster
 

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -96,11 +96,10 @@ jobs:
       - name: Update manifest snapshots
         run: |-
           helm dependency update charts/openstack-cluster && \
-            docker run -i --rm \
+            docker run -i --rm --user $(id -u) \
             -v $(pwd):/apps \
             helmunittest/helm-unittest -u \
-            charts/openstack-cluster && \
-            chown -R ${USER}:${USER} charts
+            charts/openstack-cluster
 
       - name: Write Skopeo manifest
         if: ${{ matrix.key == 'sonobuoy' }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -98,6 +98,7 @@ jobs:
           helm dependency update charts/openstack-cluster && \
             docker run -i --rm --user $(id -u) \
             -v $(pwd):/apps \
+            --tmpfs /.cache \
             helmunittest/helm-unittest -u \
             charts/openstack-cluster
 


### PR DESCRIPTION
- Fixes missing .chart reference for amdGPUOperator in addon update CI
- Revert https://github.com/azimuth-cloud/capi-helm-charts/pull/754 and add tmpfs mount for /.cache to helm-unittest invocation