### PR TITLE
Missing cloud config options from CAPI Helm Schema

### DIFF
--- a/charts/cluster-addons/values.schema.json
+++ b/charts/cluster-addons/values.schema.json
@@ -1789,11 +1789,11 @@
           "type": "object"
         },
         "cloudConfig": {
-          "additionalProperties": false,
+          "additionalProperties": true,
           "description": "cloud-config options for the OpenStack integrations\nThe [Global] section is configured to use the target cloud\nSee https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#config-openstack-cloud-controller-manager\nand https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/cinder-csi-plugin/using-cinder-csi-plugin.md#block-storage",
           "properties": {
             "BlockStorage": {
-              "additionalProperties": false,
+              "additionalProperties": true,
               "description": "By default, ignore volume AZs for Cinder as most clouds have a single globally-attachable Cinder AZ",
               "properties": {
                 "ignore-volume-az": {
@@ -1804,6 +1804,51 @@
               },
               "required": [],
               "title": "BlockStorage",
+              "type": "object"
+            },
+            "LoadBalancer": {
+              "additionalProperties": true,
+              "properties": {
+                "create-monitor": {
+                  "type": "boolean"
+                },
+                "floating-network-id": {
+                  "required": [],
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "lb-method": {
+                  "required": [],
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "lb-provider": {
+                  "required": [],
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
+            "Networking": {
+              "additionalProperties": true,
+              "properties": {
+                "internal-network-name": {
+                  "required": [],
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [],
               "type": "object"
             }
           },

--- a/charts/cluster-addons/values.yaml
+++ b/charts/cluster-addons/values.yaml
@@ -211,6 +211,44 @@ openstack:
   targetNamespace: openstack-system
   # @schema
   # type: object
+  # additionalProperties: true
+  # properties:
+  #   Networking:
+  #     type: object
+  #     additionalProperties: true
+  #     properties:
+  #       internal-network-name:
+  #         type:
+  #           - string
+  #           - "null"
+  #   LoadBalancer:
+  #     type: object
+  #     additionalProperties: true
+  #     properties:
+  #       floating-network-id:
+  #         type:
+  #           - string
+  #           - "null"
+  #       lb-provider:
+  #         type:
+  #           - string
+  #           - "null"
+  #       lb-method:
+  #         type:
+  #           - string
+  #           - "null"
+  #       create-monitor:
+  #         type: boolean
+  #   BlockStorage:
+  #     type: object
+  #     title: BlockStorage
+  #     description: By default, ignore volume AZs for Cinder as most clouds have a single globally-attachable Cinder AZ
+  #     additionalProperties: true
+  #     properties:
+  #       ignore-volume-az:
+  #         type: boolean
+  #         title: ignore-volume-az
+  #         default: true
   # @schema
   # cloud-config options for the OpenStack integrations
   # The [Global] section is configured to use the target cloud

--- a/charts/openstack-cluster/tests/values_full.yaml
+++ b/charts/openstack-cluster/tests/values_full.yaml
@@ -21,6 +21,18 @@ addons:
       enabled: true
   openstack:
     enabled: true
+    cloudConfig:
+      Networking:
+        internal-network-name: test-internal-network
+        custom-networking-option: test-networking-value
+      LoadBalancer:
+        floating-network-id: test-floating-network-id
+        lb-provider: amphora
+        lb-method: SOURCE_IP_PORT
+        create-monitor: true
+        custom-loadbalancer-option: test-loadbalancer-value
+      CustomSection:
+        custom-key: custom-value
     ccm:
       enabled: true
     csiCinder:

--- a/charts/openstack-cluster/values.schema.json
+++ b/charts/openstack-cluster/values.schema.json
@@ -1796,11 +1796,11 @@
               "type": "object"
             },
             "cloudConfig": {
-              "additionalProperties": false,
+              "additionalProperties": true,
               "description": "cloud-config options for the OpenStack integrations\nThe [Global] section is configured to use the target cloud\nSee https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#config-openstack-cloud-controller-manager\nand https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/cinder-csi-plugin/using-cinder-csi-plugin.md#block-storage",
               "properties": {
                 "BlockStorage": {
-                  "additionalProperties": false,
+                  "additionalProperties": true,
                   "description": "By default, ignore volume AZs for Cinder as most clouds have a single globally-attachable Cinder AZ",
                   "properties": {
                     "ignore-volume-az": {
@@ -1811,6 +1811,51 @@
                   },
                   "required": [],
                   "title": "BlockStorage",
+                  "type": "object"
+                },
+                "LoadBalancer": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "create-monitor": {
+                      "type": "boolean"
+                    },
+                    "floating-network-id": {
+                      "required": [],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "lb-method": {
+                      "required": [],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "lb-provider": {
+                      "required": [],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [],
+                  "type": "object"
+                },
+                "Networking": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "internal-network-name": {
+                      "required": [],
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [],
                   "type": "object"
                 }
               },


### PR DESCRIPTION

Fix `cloudConfig` schema validation for values already supported by the `cloud-config.yaml` template.

The template supports some fields that the schema is missing causing Magnum CAPI Helm installs to fail when passing valid cloud config options.

Thus, 
- Added explicitly templated options to the schema
- additionalProperties true is set for fields which allow additional fields