### PR TITLE
feat: Add default 21 days on controlplane cert expiry

### DIFF
--- a/charts/openstack-cluster/tests/__snapshot__/snapshot_base_test.yaml.snap
+++ b/charts/openstack-cluster/tests/__snapshot__/snapshot_base_test.yaml.snap
@@ -926,6 +926,8 @@ templated manifests should match snapshot:
         minHealthyPeriod: 1h
         retryPeriod: 20m
       replicas: 3
+      rolloutBefore:
+        certificatesExpiryDays: 21
       rolloutStrategy:
         rollingUpdate:
           maxSurge: 1

--- a/charts/openstack-cluster/tests/__snapshot__/snapshot_full_test.yaml.snap
+++ b/charts/openstack-cluster/tests/__snapshot__/snapshot_full_test.yaml.snap
@@ -2316,6 +2316,8 @@ templated manifests should match snapshot:
         minHealthyPeriod: 1h
         retryPeriod: 20m
       replicas: 3
+      rolloutBefore:
+        certificatesExpiryDays: 21
       rolloutStrategy:
         rollingUpdate:
           maxSurge: 1

--- a/charts/openstack-cluster/tests/__snapshot__/snapshot_ovn_test.yaml.snap
+++ b/charts/openstack-cluster/tests/__snapshot__/snapshot_ovn_test.yaml.snap
@@ -949,6 +949,8 @@ templated manifests should match snapshot:
         minHealthyPeriod: 1h
         retryPeriod: 20m
       replicas: 3
+      rolloutBefore:
+        certificatesExpiryDays: 21
       rolloutStrategy:
         rollingUpdate:
           maxSurge: 1

--- a/charts/openstack-cluster/tests/values_base.yaml
+++ b/charts/openstack-cluster/tests/values_base.yaml
@@ -2,6 +2,7 @@ kubernetesVersion: 1.29.2
 machineImage: ubuntu-jammy-kube-v{{ .Values.kubernetesVersion }}
 controlPlane:
   machineFlavor: vm.small
+  certificatesExpiryDays: 21
 nodeGroups:
   - name: group-1
     machineFlavor: vm.small

--- a/charts/openstack-cluster/values.yaml
+++ b/charts/openstack-cluster/values.yaml
@@ -352,7 +352,7 @@ controlPlane:
   # Roll out control plane machines before their certificates expire.
   # If unset, Cluster API does not trigger rollouts based on certificate expiry.
   # See https://cluster-api.sigs.k8s.io/tasks/certs/auto-rotate-certificates-in-kcp/
-  certificatesExpiryDays:
+  certificatesExpiryDays: 21
   # The kubeadm config specification for the control plane
   # By default, this uses a simple configuration that enables the external cloud provider
   kubeadmConfigSpec:


### PR DESCRIPTION
## Summary

Set default value of `certificatesExpiryDays` to `21` in the CAPI Helm chart.

with this change, controlplane machine will be automatically rolled out `21` days before kubeadm certificates expire.

## Relationships with other PRs

This change follows the instruction of:
-  https://github.com/azimuth-cloud/ansible-collection-azimuth-ops/pull/1316
- https://github.com/azimuth-cloud/ansible-collection-azimuth-ops/pull/1317

## Backwards compatibility

Existing azimuth clusters that explicitly configure `certificateExpiryDays` would not be affected.
Users can override the default value through their helm values if a different rollout threshold is needed. 