### PR TITLE
feat: Add monitor kube-api cert expiry with blackbox exporter

### DIFF
--- a/charts/cluster-addons/templates/monitoring/blackbox-exporter.yaml
+++ b/charts/cluster-addons/templates/monitoring/blackbox-exporter.yaml
@@ -8,21 +8,54 @@ metadata:
     {{- include "cluster-addons.componentLabels" (list . "blackbox-exporter") | nindent 4 }}
     addons.stackhpc.com/watch: ""
 stringData:
-  {{- if .Values.monitoring.blackboxExporter.openstackAuthUrlTarget.enabled }}
+  {{- if or .Values.monitoring.blackboxExporter.kubernetesApiTarget.enabled .Values.monitoring.blackboxExporter.openstackAuthUrlTarget.enabled }}
   defaults: |
+    {{- if .Values.monitoring.blackboxExporter.kubernetesApiTarget.enabled }}
+    # Mount the cluster CA so that the in-cluster Kubernetes API endpoint
+    # can be probed with certificate verification enabled.
+    extraConfigmapMounts:
+      - name: kube-root-ca
+        configMap: kube-root-ca.crt
+        mountPath: /etc/kubernetes-ca
+        readOnly: true
+        defaultMode: 420
+    config:
+      modules:
+        kubernetes_api:
+          prober: http
+          timeout: 5s
+          http:
+            valid_http_versions:
+              - HTTP/1.1
+              - HTTP/2.0
+            follow_redirects: true
+            preferred_ip_protocol: ip4
+            tls_config:
+              ca_file: /etc/kubernetes-ca/ca.crt
+    {{- end }}
     serviceMonitor:
       enabled: true
-      {% if cloud_identity and "clouds.yaml" in cloud_identity.data %}
-      {% set clouds_data = cloud_identity.data["clouds.yaml"] | b64decode | fromyaml %}
       targets:
+        {{- if .Values.monitoring.blackboxExporter.kubernetesApiTarget.enabled }}
+        - name: kube-api
+          # Use the short in-cluster service name so that this also works
+          # for clusters with a non-default service domain.
+          url: https://kubernetes.default.svc/livez
+          module: kubernetes_api
+        {{- end }}
+        {{- if .Values.monitoring.blackboxExporter.openstackAuthUrlTarget.enabled }}
+        {% if cloud_identity and "clouds.yaml" in cloud_identity.data %}
+        {% set clouds_data = cloud_identity.data["clouds.yaml"] | b64decode | fromyaml %}
         {% for name, config in clouds_data.clouds.items() %}
         - name: {{ "{{" }} name {{ "}}" }}-auth-url
           url: {{ "{{" }} config.auth.auth_url.strip("/").removesuffix("/v3") {{ "}}" }}/v3
         {% endfor %}
-      {% endif %}
+        {% endif %}
+        {{- end }}
   {{- else }}
   defaults: {}
   {{- end }}
+  # Additional chart values, including scrape targets, can be supplied as overrides.
   overrides: |
     {{- toYaml .Values.monitoring.blackboxExporter.release.values | nindent 4 }}
 ---
@@ -138,5 +171,21 @@ spec:
                   annotations:
                     summary: Blackbox SSL certificate expired (target {{ "{{" }} $labels.target {{ "}}" }})
                     description: "SSL certificate for blackbox probe '{{ "{{" }} $labels.target {{ "}}" }}' has expired"
+                {{- if .Values.monitoring.blackboxExporter.kubernetesApiTarget.enabled }}
+                - alert: KubeApiCertificateReplacementOverdue
+                  expr: |
+                    (
+                      min_over_time(
+                        probe_ssl_earliest_cert_expiry{target="kube-api"}[10m]
+                      )
+                      - time()
+                    ) <= (20 * 24 * 3600)
+                  for: 1h
+                  labels:
+                    severity: critical
+                  annotations:
+                    summary: Kubernetes API certificate replacement may be overdue (target {{ "{{" }} $labels.target {{ "}}" }})
+                    description: "The Kubernetes API endpoint for blackbox probe '{{ "{{" }} $labels.target {{ "}}" }}' is still serving a certificate with 20 days or less remaining. Automatic controlplane replacement should have started at the 21 day threshold but may not have completed. Operator investigation is required."
+                {{- end }}
         {% endraw %}
 {{- end }}

--- a/charts/cluster-addons/values.yaml
+++ b/charts/cluster-addons/values.yaml
@@ -323,6 +323,9 @@ monitoring:
         #   targets:
         #     - name: example
         #       url: http://example.com/healthz
+    # Indicates if a blackbox target for the in-cluster Kubernetes API should be created
+    kubernetesApiTarget:
+      enabled: true
     # Indicates if a blackbox target for the cloud's auth endpoint should be created
     openstackAuthUrlTarget:
       enabled: true

--- a/charts/openstack-cluster/tests/__snapshot__/snapshot_full_test.yaml.snap
+++ b/charts/openstack-cluster/tests/__snapshot__/snapshot_full_test.yaml.snap
@@ -854,16 +854,42 @@ templated manifests should match snapshot:
       name: RELEASE-NAME-blackbox-exporter-config
     stringData:
       defaults: |
+        # Mount the cluster CA so that the in-cluster Kubernetes API endpoint
+        # can be probed with certificate verification enabled.
+        extraConfigmapMounts:
+          - name: kube-root-ca
+            configMap: kube-root-ca.crt
+            mountPath: /etc/kubernetes-ca
+            readOnly: true
+            defaultMode: 420
+        config:
+          modules:
+            kubernetes_api:
+              prober: http
+              timeout: 5s
+              http:
+                valid_http_versions:
+                  - HTTP/1.1
+                  - HTTP/2.0
+                follow_redirects: true
+                preferred_ip_protocol: ip4
+                tls_config:
+                  ca_file: /etc/kubernetes-ca/ca.crt
         serviceMonitor:
           enabled: true
-          {% if cloud_identity and "clouds.yaml" in cloud_identity.data %}
-          {% set clouds_data = cloud_identity.data["clouds.yaml"] | b64decode | fromyaml %}
           targets:
+            - name: kube-api
+              # Use the short in-cluster service name so that this also works
+              # for clusters with a non-default service domain.
+              url: https://kubernetes.default.svc/livez
+              module: kubernetes_api
+            {% if cloud_identity and "clouds.yaml" in cloud_identity.data %}
+            {% set clouds_data = cloud_identity.data["clouds.yaml"] | b64decode | fromyaml %}
             {% for name, config in clouds_data.clouds.items() %}
             - name: {{ name }}-auth-url
               url: {{ config.auth.auth_url.strip("/").removesuffix("/v3") }}/v3
             {% endfor %}
-          {% endif %}
+            {% endif %}
       overrides: |
         {}
   33: |
@@ -981,6 +1007,20 @@ templated manifests should match snapshot:
                       annotations:
                         summary: Blackbox SSL certificate expired (target {{ $labels.target }})
                         description: "SSL certificate for blackbox probe '{{ $labels.target }}' has expired"
+                    - alert: KubeApiCertificateReplacementOverdue
+                      expr: |
+                        (
+                          min_over_time(
+                            probe_ssl_earliest_cert_expiry{target="kube-api"}[10m]
+                          )
+                          - time()
+                        ) <= (20 * 24 * 3600)
+                      for: 1h
+                      labels:
+                        severity: critical
+                      annotations:
+                        summary: Kubernetes API certificate replacement may be overdue (target {{ $labels.target }})
+                        description: "The Kubernetes API endpoint for blackbox probe '{{ $labels.target }}' is still serving a certificate with 20 days or less remaining. Automatic controlplane replacement should have started at the 21 day threshold but may not have completed. Operator investigation is required."
             {% endraw %}
       releaseName: blackbox-exporter-alerts
       targetNamespace: monitoring-system


### PR DESCRIPTION
## Short Summary

This PR adds HA management Kubernetes API target(in-cluster) to the blackbox exporter, allowing a cluster to monitor the expiry of its own `kube-apiserver` certificate.

Background: This complements the Machine based monitoring added for workload clusters. In HA structure of Azimuth, the management cluster Machines exist on the seed cluster, while `kube-prometheus-stack` runs inside the management cluster. As a result, the management cluster cannot use its local `kube-state-metrics` instance to monitor its own controlplane Machines.

From the added blackbox rule, the new target probes `https://kubernetes.default.svc/livez` using the cluster CA from the `kube-root-ca.crt` ConfigMap. so the existing generic blackbox certificate alerts automatically apply to the resulting `target="kube-api"` metrics.

A kube-apiserver's specific critical alert is also added for certificates with 20 days, since `KubeadmControlPlane(KCP)` replacement should start at the 21 day expiry threshold, this indicates that automatic replacement may not have completed. 

The rule uses the minimum expiry observed over ten minutes to account for different controlplane backends being selected by the Kubernetes Service.

## Testing

* Ran `helm lint` for the `cluster-addons` chart
* Rendered `openstack-cluster` chart with the test values
* Updated and ran the Helm snapshot tests
