### PR TITLE
Fix CI not failing if Sonobuoy tests fail

### DIFF
--- a/.github/actions/upgrade-and-test/action.yml
+++ b/.github/actions/upgrade-and-test/action.yml
@@ -210,6 +210,15 @@ runs:
         path: ./sonobuoy-results-${{ inputs.name }}.tar.gz
       if: "${{ inputs.sonobuoy-upload == 'yes' }}"
 
+    - name: Fail if sonobuoy tests fail
+      shell: bash
+      run: |
+        if sonobuoy status --json | jq -e '.plugins[] | select(."result-status" != "passed")'; then
+          exit 1;
+        fi
+      env:
+        KUBECONFIG: ./kubeconfig
+
     - name: Remove sonobuoy artifacts from cluster
       shell: bash
       run: sonobuoy delete --wait --all


### PR DESCRIPTION
The current tasks to run Sonobuoy tests exit 0 if the test orchestrator pod deploys and finishes, regardless of the results of the tests. Adds a script to query the results and fail if tests failures are found