### PR TITLE
Use github authentication in CI to avoid rate limits

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -42,7 +42,7 @@ runs:
 
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
-        python-version: '3.9'
+        python-version: "3.9"
         check-latest: true
 
     - name: Set up Helm
@@ -93,6 +93,8 @@ runs:
         # Needed to prevent clusterctl trying to pull metadata from
         # unreleased tags kubernetes-sigs/cluster-api#7889
         GOPROXY: off
+        # https://cluster-api.sigs.k8s.io/clusterctl/overview#avoiding-github-rate-limiting
+        GITHUB_TOKEN: ${{ github.token }}
 
     - name: Install openstack-resource-controller
       shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -353,10 +353,10 @@ jobs:
 
       - name: Get latest tag
         id: latest-tag
-        run: |
-          set -eo pipefail
-          TAG_NAME="$(curl -fsSL "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/latest" | jq -r '.tag_name')"
-          echo "tag-name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+        run: echo "tag-name=$(gh release view --json tagName --jq .tagName)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
 
       - name: Checkout latest tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,6 +25,8 @@ jobs:
   # For tests-full=false it uses a pre-existing internal network and runs Sonobuoy in quick mode
   latest:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -98,6 +100,8 @@ jobs:
   # This job tests a deployment against the latest version with the monitoring and ingress enabled
   latest-addons:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ inputs.tests-full }}
     steps:
       - name: Checkout
@@ -172,6 +176,8 @@ jobs:
   # It uses a pre-existing internal network and the default volume type
   etcd-volume:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ inputs.tests-full }}
     steps:
       - name: Checkout
@@ -246,6 +252,8 @@ jobs:
   # It uses a pre-existing internal network
   kube-upgrade:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ inputs.tests-full }}
     steps:
       - name: Checkout
@@ -343,6 +351,8 @@ jobs:
   # It installs ALL of the addons so that we test upgrading them
   chart-upgrade:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ inputs.tests-full }}
     steps:
       - name: Checkout current


### PR DESCRIPTION
This PR passes the Github token in a couple of places in the CI to avoid github rate limits.
1) When getting the latest release
2) Pass the github token into clusterctl: https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/clusterctl/overview.md#avoiding-github-rate-limiting